### PR TITLE
Use JWT_SECRET environment variable for token signing

### DIFF
--- a/api/controllers/auth.controller.js
+++ b/api/controllers/auth.controller.js
@@ -12,7 +12,7 @@ import jwt from 'jsonwebtoken';
  * @returns {string} Signed JSON Web Token.
  */
 const signToken = (payload) => {
-  const secret = 'viren';
+  const secret = process.env.JWT_SECRET;
   if (!secret) {
     // Using the same error handler ensures consistent error responses
     throw errorHandler(500, 'JWT secret is missing');


### PR DESCRIPTION
## Summary
- Fix authentication token generation to use JWT_SECRET from environment instead of a hardcoded value

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68b045685e748330a63f1efdaab98249