### PR TITLE
feat: expose tutorial categories endpoint

### DIFF
--- a/api/controllers/tutorial.controller.js
+++ b/api/controllers/tutorial.controller.js
@@ -95,6 +95,16 @@ export const getTutorials = async (req, res, next) => {
     }
 };
 
+// Fetch distinct tutorial categories
+export const getTutorialCategories = async (req, res, next) => {
+    try {
+        const categories = await Tutorial.distinct('category');
+        res.status(200).json(categories);
+    } catch (error) {
+        next(error);
+    }
+};
+
 export const updateTutorial = async (req, res, next) => {
     if (!req.user.isAdmin && req.user.id !== req.params.userId) {
         return next(errorHandler(403, 'You are not allowed to update this tutorial'));

--- a/api/routes/tutorial.route.js
+++ b/api/routes/tutorial.route.js
@@ -3,6 +3,7 @@ import { verifyToken } from '../utils/verifyUser.js';
 import {
     createTutorial,
     getTutorials,
+    getTutorialCategories,
     updateTutorial,
     deleteTutorial,
     addChapter,
@@ -16,6 +17,7 @@ const router = express.Router();
 // Tutorial CRUD operations (admin-only)
 router.post('/create', verifyToken, createTutorial);
 router.get('/gettutorials', getTutorials);
+router.get('/categories', getTutorialCategories);
 router.get('/getsingletutorial/:tutorialSlug', (req, res, next) => {
     req.query.slug = req.params.tutorialSlug;
     getTutorials(req, res, next);

--- a/client/src/pages/Tutorials.jsx
+++ b/client/src/pages/Tutorials.jsx
@@ -6,7 +6,7 @@ import { Spinner, Alert, Button, TextInput, Select } from 'flowbite-react';
 import { motion } from 'framer-motion';
 
 import TutorialCard from '../components/TutorialCard';
-import { getTutorials } from '../services/tutorialService.js';
+import { getTutorials, getCategories } from '../services/tutorialService.js';
 import TutorialCardSkeleton from '../components/TutorialCardSkeleton'; // <-- Import the new skeleton component
 
 export default function Tutorials() {
@@ -60,17 +60,13 @@ export default function Tutorials() {
         navigate({ search: urlParams.toString() });
     };
 
-    const { data: categoriesData, isLoading: categoriesLoading, isError: categoriesError } = useQuery({
+    const {
+        data: categoriesData,
+        isLoading: categoriesLoading,
+        isError: categoriesError,
+    } = useQuery({
         queryKey: ['tutorialCategories'],
-        queryFn: async () => {
-            return new Promise(resolve => {
-                setTimeout(() => {
-                    resolve([
-                        'JavaScript', 'React.js', 'Next.js', 'CSS', 'HTML', 'Node.js', 'C++', 'Python', 'Go', 'PHP', 'TypeScript', 'Data Science', 'Machine Learning'
-                    ]);
-                }, 500);
-            });
-        },
+        queryFn: getCategories,
         staleTime: Infinity,
     });
 

--- a/client/src/services/tutorialService.js
+++ b/client/src/services/tutorialService.js
@@ -19,6 +19,12 @@ export const getTutorials = async (searchQuery = '') => {
     return data;
 };
 
+// Fetch all distinct tutorial categories
+export const getCategories = async () => {
+    const { data } = await API.get('/api/tutorial/categories');
+    return data;
+};
+
 /**
  * Creates a new tutorial.
  * @param {object} formData - The tutorial data to create.
@@ -100,6 +106,7 @@ export const deleteChapter = async ({ tutorialId, chapterId, userId }) => {
 
 export default {
     getTutorials,
+    getCategories,
     createTutorial,
     updateTutorial,
     deleteTutorial,


### PR DESCRIPTION
## Summary
- add `/api/tutorial/categories` endpoint returning distinct categories
- client tutorial service fetches categories via new `getCategories`
- Tutorials page now queries backend categories and handles load/error states

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68b08a181bd083308c8262cde84729c5