### PR TITLE
Fix chapter completion detection using ObjectId comparison

### DIFF
--- a/api/controllers/tutorial.controller.js
+++ b/api/controllers/tutorial.controller.js
@@ -267,7 +267,7 @@ export const markChapterAsComplete = async (req, res, next) => {
             return next(errorHandler(404, 'Chapter not found.'));
         }
 
-        if (chapter.completedBy.includes(userId)) {
+        if (chapter.completedBy.some(id => id.toString() === userId)) {
             return next(errorHandler(400, 'Chapter already marked as complete by this user.'));
         }
 

--- a/api/utils/completedBy.test.js
+++ b/api/utils/completedBy.test.js
@@ -1,0 +1,15 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import mongoose from 'mongoose';
+
+test('detects completed user when using ObjectId comparison', () => {
+    const userId = new mongoose.Types.ObjectId();
+    const chapter = { completedBy: [userId] };
+
+    // Ensure direct includes fails with mixed types
+    assert.strictEqual(chapter.completedBy.includes(userId.toString()), false);
+
+    // Correct detection using toString comparison
+    const detected = chapter.completedBy.some(id => id.toString() === userId.toString());
+    assert.strictEqual(detected, true);
+});

--- a/client/src/pages/SingleTutorialPage.jsx
+++ b/client/src/pages/SingleTutorialPage.jsx
@@ -129,7 +129,7 @@ const ChapterContent = ({ activeChapter, sanitizedContent, parserOptions }) => {
 };
 
 const ChapterLink = ({ chapter, tutorial, activeChapterId, currentUser }) => {
-    const isCompleted = currentUser && chapter.completedBy?.includes(currentUser._id);
+    const isCompleted = currentUser && chapter.completedBy?.some(id => id.toString() === currentUser._id);
     const isActive = activeChapterId === chapter._id;
 
     const Icon =
@@ -286,7 +286,7 @@ export default function SingleTutorialPage() {
     const countCompletedChapters = (chapters) => {
         if (!chapters) return 0;
         return chapters.reduce((count, chapter) => {
-            const isCompleted = chapter.completedBy?.includes(currentUser._id);
+            const isCompleted = chapter.completedBy?.some(id => id.toString() === currentUser._id);
             const subChapterCount = chapter.subChapters ? countCompletedChapters(chapter.subChapters) : 0;
             return count + (isCompleted ? 1 : 0) + subChapterCount;
         }, 0);
@@ -302,7 +302,7 @@ export default function SingleTutorialPage() {
 
     useEffect(() => {
         if (activeChapter && currentUser) {
-            const completed = activeChapter.completedBy && activeChapter.completedBy.includes(currentUser._id);
+            const completed = activeChapter.completedBy && activeChapter.completedBy.some(id => id.toString() === currentUser._id);
             setIsCompleted(completed);
         } else { setIsCompleted(false); }
     }, [activeChapter, currentUser]);


### PR DESCRIPTION
## Summary
- ensure server checks chapter completion with ObjectId string comparison
- mirror ObjectId comparison for chapter completion checks on SingleTutorialPage
- add regression test verifying completedBy detection

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68b188f9ce188327bfba8a7bca12b35c