### PR TITLE
Improve tutorial docs and reading time

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,14 @@ ScientistShieldOne is a MERN-stack application for sharing knowledge and practic
    npm start
    ```
 
+## Managing Tutorials
+- `GET /api/tutorial/gettutorials` – list all tutorials.
+- `GET /api/tutorial/getsingleTutorial/:tutorialSlug` – fetch a tutorial by slug.
+- `POST /api/tutorial/create/:userId` – create a new tutorial (requires auth).
+- `PUT /api/tutorial/update/:tutorialId/:userId` – update an existing tutorial.
+- `DELETE /api/tutorial/delete/:tutorialId/:userId` – remove a tutorial.
+
 ## Contribution Guidelines
 1. Fork the repository and create a new branch for your feature or fix.
 2. Make your changes and run any available tests (`npm test`).
-3. Commit your changes with a clear message and open a pull request.# ScientistShield_0.1
-# ScientistShield0.2
+3. Commit your changes with a clear message and open a pull request.

--- a/client/src/components/TutorialCard.jsx
+++ b/client/src/components/TutorialCard.jsx
@@ -38,8 +38,11 @@ const TutorialCard = ({ tutorial }) => {
         ["-10px 10px 20px rgba(0,0,0,0.2)", "10px 10px 20px rgba(0,0,0,0.2)"]
     ), { stiffness: 300, damping: 10 });
 
-    // FIX: Safely access tutorial.content and use a default value if it's undefined
-    const readingTime = Math.ceil((tutorial.content?.length || 0) / 1000) || 5;
+    // Estimate reading time based on a ~200 wpm average
+    const wordCount = tutorial.content
+        ? tutorial.content.replace(/<[^>]+>/g, '').trim().split(/\s+/).length
+        : 0;
+    const readingTime = Math.max(1, Math.ceil(wordCount / 200));
 
     return (
         <Link to={`/tutorials/${tutorial.slug}`} className="block h-full">


### PR DESCRIPTION
## Summary
- Document tutorial-related API endpoints in README
- Use word-count to estimate tutorial card reading time

## Testing
- `npm test`
- `npm test --prefix client` *(fails: Missing script: "test")*
- `npm run lint --prefix client` *(fails: 377 problems)*

------
https://chatgpt.com/codex/tasks/task_b_68b25298cdac832788348c5136d0bbb0