### PR TITLE
feat: enhance Try It Yourself experience

### DIFF
--- a/client/src/components/CodeEditor.jsx
+++ b/client/src/components/CodeEditor.jsx
@@ -3,7 +3,7 @@ import React, { useState, useEffect, useRef } from 'react';
 import Editor from '@monaco-editor/react';
 import { Button, ToggleSwitch, Spinner, Alert } from 'flowbite-react';
 import { useSelector } from 'react-redux';
-import { FaPlay, FaRedo, FaChevronRight, FaChevronDown, FaTerminal, FaSave } from 'react-icons/fa';
+import { FaPlay, FaRedo, FaChevronRight, FaChevronDown, FaTerminal, FaSave, FaEye, FaEyeSlash } from 'react-icons/fa';
 import { motion, AnimatePresence } from 'framer-motion';
 
 import LanguageSelector from './LanguageSelector';
@@ -16,7 +16,7 @@ const defaultCodes = {
     python: `print("Hello, Python!")`
 };
 
-export default function CodeEditor({ initialCode = {}, language = 'html' }) {
+export default function CodeEditor({ initialCode = {}, language = 'html', expectedOutput = '' }) {
     const { theme } = useSelector((state) => state.theme);
     const outputRef = useRef(null);
 
@@ -36,6 +36,7 @@ export default function CodeEditor({ initialCode = {}, language = 'html' }) {
     const [isRunning, setIsRunning] = useState(false);
     const [runError, setRunError] = useState(null);
     const [showOutputPanel, setShowOutputPanel] = useState(true);
+    const [showAnswer, setShowAnswer] = useState(false);
 
     const handleCodeChange = (newCode) => {
         setCodes(prevCodes => ({
@@ -193,6 +194,21 @@ export default function CodeEditor({ initialCode = {}, language = 'html' }) {
                             <FaRedo className="mr-2 h-4 w-4" /> Reset
                         </Button>
                     </motion.div>
+                    {expectedOutput && (
+                        <motion.div
+                            whileHover={{ scale: 1.05 }}
+                            whileTap={{ scale: 0.95 }}
+                        >
+                            <Button outline gradientDuoTone="greenToBlue" onClick={() => setShowAnswer(!showAnswer)}>
+                                {showAnswer ? (
+                                    <FaEyeSlash className="mr-2 h-4 w-4" />
+                                ) : (
+                                    <FaEye className="mr-2 h-4 w-4" />
+                                )}
+                                {showAnswer ? 'Hide Answer' : 'Show Answer'}
+                            </Button>
+                        </motion.div>
+                    )}
                 </div>
             </div>
             <div className="flex-1 flex flex-col md:flex-row gap-4 overflow-hidden">
@@ -291,6 +307,12 @@ export default function CodeEditor({ initialCode = {}, language = 'html' }) {
                                         </div>
                                     )}
                                 </div>
+                                {showAnswer && expectedOutput && (
+                                    <div className="mt-2 p-2 rounded-md bg-gray-100 dark:bg-gray-700">
+                                        <h4 className="text-sm font-semibold mb-1 text-gray-700 dark:text-gray-300">Expected Output</h4>
+                                        <pre className="whitespace-pre-wrap text-xs text-gray-800 dark:text-gray-200">{expectedOutput}</pre>
+                                    </div>
+                                )}
                             </div>
                         </motion.div>
                     </AnimatePresence>

--- a/client/src/components/InteractiveCodeBlock.jsx
+++ b/client/src/components/InteractiveCodeBlock.jsx
@@ -4,10 +4,8 @@ import { motion, AnimatePresence } from 'framer-motion';
 import { Button } from 'flowbite-react';
 import { FaPlayCircle, FaCode, FaTimes, FaExternalLinkAlt } from 'react-icons/fa';
 import CodeEditor from './CodeEditor';
-import { useNavigate } from 'react-router-dom';
 
 export default function InteractiveCodeBlock({ initialCode, language }) {
-    const navigate = useNavigate();
     const [isInteractive, setIsInteractive] = useState(false);
 
     const handleToggle = () => {
@@ -15,7 +13,8 @@ export default function InteractiveCodeBlock({ initialCode, language }) {
     };
 
     const handleOpenInNewTab = () => {
-        navigate('/tryit', { state: { code: initialCode, language: language } });
+        const url = `/tryit?code=${encodeURIComponent(initialCode)}&language=${language}`;
+        window.open(url, '_blank', 'noopener,noreferrer');
     };
 
     const containerVariants = {

--- a/client/src/pages/SingleTutorialPage.jsx
+++ b/client/src/pages/SingleTutorialPage.jsx
@@ -89,8 +89,9 @@ const ChapterContent = ({ activeChapter, sanitizedContent, parserOptions }) => {
                     <h3 className='text-xl font-semibold mb-3 flex items-center gap-2'><FaCode /> Try it yourself!</h3>
                     <div className='post-content tiptap mb-4' dangerouslySetInnerHTML={{ __html: sanitizedContent }} />
                     <CodeEditor
-                        initialCode={activeChapter.initialCode || ''}
+                        initialCode={{ [activeChapter.codeLanguage || 'html']: activeChapter.initialCode || '' }}
                         language={activeChapter.codeLanguage || 'html'}
+                        expectedOutput={activeChapter.expectedOutput || ''}
                     />
                 </motion.div>
             );

--- a/client/src/pages/TryItPage.jsx
+++ b/client/src/pages/TryItPage.jsx
@@ -1,14 +1,25 @@
 import React, { useState, useEffect } from 'react';
 import { useLocation } from 'react-router-dom';
 import CodeEditor from '../components/CodeEditor';
-import { Alert, Button } from 'flowbite-react';
-import { FaExternalLinkAlt } from 'react-icons/fa';
+import { Alert } from 'flowbite-react';
 
 export default function TryItPage() {
     const location = useLocation();
-    const { code, language } = location.state || { code: null, language: null };
-    const [editorCode, setEditorCode] = useState(code || '');
-    const [editorLanguage, setEditorLanguage] = useState(language || 'javascript');
+    const searchParams = new URLSearchParams(location.search);
+    const stateCode = location.state?.code;
+    const stateLanguage = location.state?.language;
+    const stateExpected = location.state?.expectedOutput;
+    const queryCode = searchParams.get('code');
+    const queryLanguage = searchParams.get('language');
+    const queryExpected = searchParams.get('expectedOutput');
+
+    const initialCode = stateCode || (queryCode ? decodeURIComponent(queryCode) : null);
+    const initialLanguage = stateLanguage || queryLanguage || 'javascript';
+    const initialExpected = stateExpected || (queryExpected ? decodeURIComponent(queryExpected) : '');
+
+    const [editorCode, setEditorCode] = useState(initialCode || '');
+    const [editorLanguage, setEditorLanguage] = useState(initialLanguage || 'javascript');
+    const [expectedOutput] = useState(initialExpected);
 
     // Default message when there's no initial code
     const defaultCodeMessage = `// Welcome to the live code editor!
@@ -18,14 +29,14 @@ export default function TryItPage() {
 
     useEffect(() => {
         // Set the initial code based on the language, or a default message if none is provided.
-        if (!code && !language) {
+        if (!initialCode) {
             setEditorCode(defaultCodeMessage);
             setEditorLanguage('javascript');
         } else {
-            setEditorCode(code);
-            setEditorLanguage(language);
+            setEditorCode(initialCode);
+            setEditorLanguage(initialLanguage || 'javascript');
         }
-    }, [code, language]);
+    }, [initialCode, initialLanguage]);
 
     return (
         <div className="min-h-screen p-6 bg-gray-50 dark:bg-gray-900 text-gray-800 dark:text-gray-200">
@@ -44,8 +55,9 @@ export default function TryItPage() {
                 </Alert>
 
                 <CodeEditor
-                    initialCode={editorCode}
+                    initialCode={{ [editorLanguage]: editorCode }}
                     language={editorLanguage}
+                    expectedOutput={expectedOutput}
                 />
             </div>
         </div>


### PR DESCRIPTION
## Summary
- open "Try it Yourself" code blocks in a dedicated page via new tab button
- add optional "Show Answer" capability to CodeEditor using chapter expected output
- support query params on TryItPage for code, language, and expected output

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68b26bbf6f548327953bc0120ee31479