### PR TITLE
feat: add video chapter type

### DIFF
--- a/api/controllers/tutorial.controller.js
+++ b/api/controllers/tutorial.controller.js
@@ -166,8 +166,8 @@ export const addChapter = async (req, res, next) => {
     if (!chapterTitle || order === undefined) {
         return next(errorHandler(400, 'Chapter title and order are required.'));
     }
-    if (contentType === 'text' && !content) {
-        return next(errorHandler(400, 'Chapter content is required for text chapters.'));
+    if ((contentType === 'text' || contentType === 'video') && !content) {
+        return next(errorHandler(400, 'Chapter content is required for text and video chapters.'));
     }
     if (contentType === 'code-interactive' && !initialCode) {
         return next(errorHandler(400, 'Initial code is required for interactive code chapters.'));
@@ -209,6 +209,17 @@ export const updateChapter = async (req, res, next) => {
         return next(errorHandler(403, 'You are not allowed to update this chapter'));
     }
     const { chapterTitle, content, order, contentType, initialCode, expectedOutput, quizId } = req.body;
+
+    if ((contentType === 'text' || contentType === 'video') && !content) {
+        return next(errorHandler(400, 'Chapter content is required for text and video chapters.'));
+    }
+    if (contentType === 'code-interactive' && !initialCode) {
+        return next(errorHandler(400, 'Initial code is required for interactive code chapters.'));
+    }
+    if (contentType === 'quiz' && !quizId) {
+        return next(errorHandler(400, 'A quiz ID is required for quiz chapters.'));
+    }
+
     const updateFields = {};
     if (chapterTitle !== undefined) updateFields.chapterTitle = chapterTitle;
     if (content !== undefined) updateFields.content = content;

--- a/api/models/tutorial.model.js
+++ b/api/models/tutorial.model.js
@@ -13,7 +13,7 @@ const subChapterSchema = new mongoose.Schema(
         },
         contentType: {
             type: String,
-            enum: ['text', 'code-interactive', 'quiz'],
+            enum: ['text', 'code-interactive', 'quiz', 'video'],
             default: 'text',
         },
         content: {
@@ -54,7 +54,7 @@ const tutorialChapterSchema = new mongoose.Schema(
         },
         contentType: {
             type: String,
-            enum: ['text', 'code-interactive', 'quiz'],
+            enum: ['text', 'code-interactive', 'quiz', 'video'],
             default: 'text',
         },
         content: {

--- a/client/src/components/DraggableChapter.jsx
+++ b/client/src/components/DraggableChapter.jsx
@@ -2,7 +2,7 @@
 import { useRef, useState, useMemo } from 'react';
 import { useDrag, useDrop } from 'react-dnd';
 import { Button, Select, TextInput, Textarea, Spinner, Alert, Tooltip } from 'flowbite-react';
-import { FaTrash, FaChevronUp, FaChevronDown, FaCode, FaBook, FaList, FaQuestionCircle } from 'react-icons/fa';
+import { FaTrash, FaChevronUp, FaChevronDown, FaCode, FaBook, FaList, FaQuestionCircle, FaVideo } from 'react-icons/fa';
 import TiptapEditor from './TiptapEditor';
 import { motion } from 'framer-motion';
 
@@ -75,6 +75,7 @@ const DraggableChapter = ({
             case 'text': return <FaBook className="text-teal-500" />;
             case 'code-interactive': return <FaCode className="text-blue-500" />;
             case 'quiz': return <FaList className="text-purple-500" />;
+            case 'video': return <FaVideo className="text-red-500" />;
             default: return null;
         }
     };
@@ -89,6 +90,17 @@ const DraggableChapter = ({
                             content={chapter.content || ''}
                             onChange={(newContent) => handleChapterContentChange(index, newContent)}
                             placeholder="Start writing your chapter content here..."
+                        />
+                    </div>
+                );
+            case 'video':
+                return (
+                    <div className='flex flex-col gap-2'>
+                        <p className="text-sm font-semibold text-gray-700 dark:text-gray-300">Video Content</p>
+                        <TiptapEditor
+                            content={chapter.content || ''}
+                            onChange={(newContent) => handleChapterContentChange(index, newContent)}
+                            placeholder="Embed a video via the toolbar or paste embed code..."
                         />
                     </div>
                 );
@@ -181,6 +193,7 @@ const DraggableChapter = ({
                             {chapter.contentType === 'text' && 'Text Content'}
                             {chapter.contentType === 'code-interactive' && 'Code Example'}
                             {chapter.contentType === 'quiz' && 'Quiz'}
+                            {chapter.contentType === 'video' && 'Video'}
                         </span>
                     </span>
                     <Button onClick={(e) => { e.stopPropagation(); handleRemoveChapter(); }} color="failure" size="xs" outline>
@@ -217,6 +230,7 @@ const DraggableChapter = ({
                             onClick={(e) => e.stopPropagation()}
                         >
                             <option value="text">Text Content</option>
+                            <option value="video">Video Content</option>
                             <option value="code-interactive">Interactive Code Example</option>
                             <option value="quiz">Linked Quiz</option>
                         </Select>

--- a/client/src/pages/CreateTutorial.jsx
+++ b/client/src/pages/CreateTutorial.jsx
@@ -233,6 +233,7 @@ const NestedChapterList = ({ chapters, handleChapterFieldChange, handleChapterCo
                             onChange={(e) => handleChapterFieldChange(chapter._id, 'contentType', e.target.value)}
                         >
                             <option value='text'>Text Content</option>
+                            <option value='video'>Video Content</option>
                             <option value='code-interactive'>Interactive Code Example</option>
                             <option value='quiz'>Linked Quiz</option>
                         </Select>
@@ -241,6 +242,13 @@ const NestedChapterList = ({ chapters, handleChapterFieldChange, handleChapterCo
                             <TiptapEditor
                                 content={chapter.content}
                                 onChange={html => handleChapterContentChange(chapter._id, html)}
+                            />
+                        )}
+                        {chapter.contentType === 'video' && (
+                            <TiptapEditor
+                                content={chapter.content}
+                                onChange={html => handleChapterContentChange(chapter._id, html)}
+                                placeholder='Embed a video via the toolbar or paste HTML code'
                             />
                         )}
                         {chapter.contentType === 'code-interactive' && (
@@ -444,9 +452,10 @@ export default function CreateTutorial() {
                 dispatch({ type: 'PUBLISH_ERROR', payload: `Chapter with slug '${chapter.chapterSlug}': Title is required.` });
                 return false;
             }
-            if (chapter.contentType === 'text' || chapter.contentType === 'code-interactive') {
-                if (chapter.contentType === 'text' && (!chapter.content || chapter.content.replace(/<(.|\n)*?>/g, '').trim().length === 0)) {
-                    dispatch({ type: 'PUBLISH_ERROR', payload: `Chapter with title '${chapter.chapterTitle}': Text content cannot be empty for 'Text Content' type.` });
+            if (['text', 'video'].includes(chapter.contentType)) {
+                if (!chapter.content || chapter.content.replace(/<(.|\n)*?>/g, '').trim().length === 0) {
+                    const typeLabel = chapter.contentType === 'video' ? 'Video' : 'Text';
+                    dispatch({ type: 'PUBLISH_ERROR', payload: `Chapter with title '${chapter.chapterTitle}': ${typeLabel} content cannot be empty for '${typeLabel} Content' type.` });
                     return false;
                 }
             }

--- a/client/src/pages/SingleTutorialPage.jsx
+++ b/client/src/pages/SingleTutorialPage.jsx
@@ -23,7 +23,7 @@ import InteractiveCodeBlock from '../components/InteractiveCodeBlock.jsx';
 import '../Tiptap.css';
 import '../pages/Scrollbar.css';
 
-import { FaCode, FaQuestionCircle, FaArrowLeft, FaArrowRight } from 'react-icons/fa';
+import { FaCode, FaQuestionCircle, FaArrowLeft, FaArrowRight, FaVideo } from 'react-icons/fa';
 import { HiCheckCircle, HiExternalLink } from 'react-icons/hi';
 import { HiOutlineUserCircle, HiOutlineDocumentText } from 'react-icons/hi2';
 
@@ -111,6 +111,20 @@ const ChapterContent = ({ activeChapter, sanitizedContent, parserOptions }) => {
                     <QuizComponent quizId={activeChapter.quizId} />
                 </motion.div>
             );
+        case 'video':
+            // Renders video or rich media content embedded via Tiptap.
+            return (
+                <motion.div
+                    key="video-content"
+                    initial={{ opacity: 0, y: 20 }}
+                    animate={{ opacity: 1, y: 0 }}
+                    exit={{ opacity: 0, y: -20 }}
+                    transition={{ duration: 0.4 }}
+                    className='post-content tiptap p-3 max-w-full mx-auto leading-relaxed text-lg text-gray-700 dark:text-gray-300'
+                >
+                    {parse(sanitizedContent, parserOptions)}
+                </motion.div>
+            );
         case 'text':
         default:
             // Renders standard text content from the Tiptap editor.
@@ -136,7 +150,8 @@ const ChapterLink = ({ chapter, tutorial, activeChapterId, currentUser }) => {
     const Icon =
         chapter.contentType === 'code-interactive' ? FaCode :
             chapter.contentType === 'quiz' ? FaQuestionCircle :
-                HiOutlineDocumentText;
+                chapter.contentType === 'video' ? FaVideo :
+                    HiOutlineDocumentText;
 
     return (
         <motion.li

--- a/client/src/types.ts
+++ b/client/src/types.ts
@@ -24,7 +24,7 @@ export interface TutorialChapter {
     chapterSlug: string;
     content: string;
     order: number;
-    contentType?: 'text' | 'code-interactive' | 'quiz'; // NEW
+    contentType?: 'text' | 'code-interactive' | 'quiz' | 'video'; // NEW
     initialCode?: string; // NEW
     expectedOutput?: string; // NEW
     quizId?: string; // NEW


### PR DESCRIPTION
## Summary
- support new `video` chapter type in tutorial schema and controller validations
- allow creating and editing video chapters in UI with Tiptap editor
- render video chapters in tutorial page and update icons and types

## Testing
- `npm test`
- `npm --prefix client run lint` *(fails: Spinner is defined but never used, etc.)*

------
https://chatgpt.com/codex/tasks/task_b_68b28dd06b588327a20cce07a6d3f3d0