### PR TITLE
feat: add code snippet sharing

### DIFF
--- a/api/controllers/codeSnippet.controller.js
+++ b/api/controllers/codeSnippet.controller.js
@@ -8,8 +8,8 @@ export const createCodeSnippet = async (req, res, next) => {
     if (!req.user.isAdmin) {
         return next(errorHandler(403, 'You are not allowed to create a code snippet'));
     }
-    const { html = '', css = '', js = '' } = req.body;
-    const newSnippet = new CodeSnippet({ html, css, js });
+    const { html = '', css = '', js = '', cpp = '', python = '' } = req.body;
+    const newSnippet = new CodeSnippet({ html, css, js, cpp, python });
 
     try {
         const savedSnippet = await newSnippet.save();
@@ -29,6 +29,21 @@ export const getCodeSnippet = async (req, res, next) => {
             return next(errorHandler(404, 'Code snippet not found.'));
         }
         res.status(200).json(snippet);
+    } catch (error) {
+        next(error);
+    }
+};
+
+/**
+ * Saves a code snippet and returns its ID for sharing.
+ */
+export const saveCodeSnippet = async (req, res, next) => {
+    const { html = '', css = '', js = '', cpp = '', python = '' } = req.body;
+    const newSnippet = new CodeSnippet({ html, css, js, cpp, python });
+
+    try {
+        const savedSnippet = await newSnippet.save();
+        res.status(201).json(savedSnippet);
     } catch (error) {
         next(error);
     }

--- a/api/models/CodeSnippet.model.js
+++ b/api/models/CodeSnippet.model.js
@@ -14,6 +14,14 @@ const CodeSnippetSchema = new mongoose.Schema(
             type: String,
             default: '',
         },
+        cpp: {
+            type: String,
+            default: '',
+        },
+        python: {
+            type: String,
+            default: '',
+        },
     },
     { timestamps: true }
 );

--- a/api/routes/codeSnippet.route.js
+++ b/api/routes/codeSnippet.route.js
@@ -1,10 +1,11 @@
 import express from 'express';
 import { verifyToken } from '../utils/verifyUser.js';
-import { createCodeSnippet, getCodeSnippet } from '../controllers/codeSnippet.controller.js';
+import { createCodeSnippet, getCodeSnippet, saveCodeSnippet } from '../controllers/codeSnippet.controller.js';
 
 const router = express.Router();
 
 router.post('/create', verifyToken, createCodeSnippet);
+router.post('/save', saveCodeSnippet);
 router.get('/:snippetId', getCodeSnippet);
 
 export default router;

--- a/client/src/components/CodeEditor.jsx
+++ b/client/src/components/CodeEditor.jsx
@@ -37,6 +37,8 @@ export default function CodeEditor({ initialCode = {}, language = 'html', expect
     const [runError, setRunError] = useState(null);
     const [showOutputPanel, setShowOutputPanel] = useState(true);
     const [showAnswer, setShowAnswer] = useState(false);
+    const [isSaving, setIsSaving] = useState(false);
+    const [shareMessage, setShareMessage] = useState('');
 
     const handleCodeChange = (newCode) => {
         setCodes(prevCodes => ({
@@ -120,6 +122,37 @@ export default function CodeEditor({ initialCode = {}, language = 'html', expect
         }
     };
 
+    const saveSnippet = async () => {
+        setIsSaving(true);
+        setShareMessage('');
+        try {
+            const res = await fetch('/api/code-snippet/save', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    html: codes.html,
+                    css: codes.css,
+                    js: codes.javascript,
+                    cpp: codes.cpp,
+                    python: codes.python,
+                }),
+            });
+            const data = await res.json();
+            if (!res.ok) {
+                throw new Error(data.message || 'Failed to save snippet');
+            }
+            const link = `${window.location.origin}/tryit?snippetId=${data._id}&language=${selectedLanguage}`;
+            await navigator.clipboard.writeText(link);
+            setShareMessage('Link copied to clipboard!');
+        } catch (error) {
+            console.error(error);
+            setShareMessage('Failed to save snippet.');
+        } finally {
+            setIsSaving(false);
+            setTimeout(() => setShareMessage(''), 3000);
+        }
+    };
+
     const isLivePreviewLanguage = selectedLanguage === 'html' || selectedLanguage === 'css' || selectedLanguage === 'javascript';
 
     useEffect(() => {
@@ -194,6 +227,14 @@ export default function CodeEditor({ initialCode = {}, language = 'html', expect
                             <FaRedo className="mr-2 h-4 w-4" /> Reset
                         </Button>
                     </motion.div>
+                    <motion.div
+                        whileHover={{ scale: 1.05 }}
+                        whileTap={{ scale: 0.95 }}
+                    >
+                        <Button outline gradientDuoTone="purpleToBlue" onClick={saveSnippet} isProcessing={isSaving} disabled={isSaving}>
+                            <FaSave className="mr-2 h-4 w-4" /> Save & Share
+                        </Button>
+                    </motion.div>
                     {expectedOutput && (
                         <motion.div
                             whileHover={{ scale: 1.05 }}
@@ -211,6 +252,11 @@ export default function CodeEditor({ initialCode = {}, language = 'html', expect
                     )}
                 </div>
             </div>
+            {shareMessage && (
+                <Alert color={shareMessage.includes('Failed') ? 'failure' : 'success'} className="mb-4">
+                    {shareMessage}
+                </Alert>
+            )}
             <div className="flex-1 flex flex-col md:flex-row gap-4 overflow-hidden">
                 <div className={`flex-1 flex flex-col rounded-md shadow-inner bg-white dark:bg-gray-800 p-2 ${isLivePreviewLanguage && showOutputPanel ? '' : 'w-full'}`}>
                     <div className="flex-1 rounded-md overflow-hidden">


### PR DESCRIPTION
## Summary
- extend CodeSnippet model to store multi-language snippets
- add save endpoint to create shareable links
- enhance CodeEditor with "Save & Share" button and TryItPage support

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68b295861ab88327b9f73ccd9c6fec80