### PR TITLE
feat: full-screen try-it editor and answer toggle

### DIFF
--- a/client/src/components/CodeEditor.jsx
+++ b/client/src/components/CodeEditor.jsx
@@ -37,6 +37,7 @@ export default function CodeEditor({ initialCode = {}, language = 'html', expect
     const [isRunning, setIsRunning] = useState(false);
     const [runError, setRunError] = useState(null);
     const [showOutputPanel, setShowOutputPanel] = useState(true);
+    // Toggle visibility of the expected output panel
     const [showAnswer, setShowAnswer] = useState(false);
     const [isSaving, setIsSaving] = useState(false);
     const [shareMessage, setShareMessage] = useState('');

--- a/client/src/components/InteractiveCodeBlock.jsx
+++ b/client/src/components/InteractiveCodeBlock.jsx
@@ -1,19 +1,13 @@
 // client/src/components/InteractiveCodeBlock.jsx
-import React, { useState } from 'react';
-import { motion, AnimatePresence } from 'framer-motion';
+import React from 'react';
+import { motion } from 'framer-motion';
 import { Button } from 'flowbite-react';
-import { FaPlayCircle, FaCode, FaTimes, FaExternalLinkAlt } from 'react-icons/fa';
-import CodeEditor from './CodeEditor';
+import { FaPlayCircle, FaCode } from 'react-icons/fa';
 
-export default function InteractiveCodeBlock({ initialCode, language }) {
-    const [isInteractive, setIsInteractive] = useState(false);
-
-    const handleToggle = () => {
-        setIsInteractive(!isInteractive);
-    };
-
+export default function InteractiveCodeBlock({ initialCode, language, expectedOutput = '' }) {
     const handleOpenInNewTab = () => {
-        const url = `/tryit?code=${encodeURIComponent(initialCode)}&language=${language}`;
+        const url = `/tryit?code=${encodeURIComponent(initialCode)}&language=${language}` +
+            (expectedOutput ? `&expectedOutput=${encodeURIComponent(expectedOutput)}` : '');
         window.open(url, '_blank', 'noopener,noreferrer');
     };
 
@@ -22,30 +16,14 @@ export default function InteractiveCodeBlock({ initialCode, language }) {
         visible: {
             opacity: 1,
             y: 0,
-            transition: { type: "spring", stiffness: 80, duration: 0.5 }
-        }
-    };
-
-    const contentVariants = {
-        hidden: { opacity: 0, height: 0, y: -20 },
-        visible: {
-            opacity: 1,
-            height: 'auto',
-            y: 0,
-            transition: { duration: 0.4, ease: 'easeOut' }
-        },
-        exit: {
-            opacity: 0,
-            height: 0,
-            y: -20,
-            transition: { duration: 0.3, ease: 'easeIn' }
+            transition: { type: 'spring', stiffness: 80, duration: 0.5 }
         }
     };
 
     const motionWrapperProps = {
         whileHover: { scale: 1.05 },
         whileTap: { scale: 0.95 },
-        transition: { type: "spring", stiffness: 400, damping: 10 },
+        transition: { type: 'spring', stiffness: 400, damping: 10 },
         style: { display: 'inline-block' },
     };
 
@@ -64,63 +42,20 @@ export default function InteractiveCodeBlock({ initialCode, language }) {
                     <Button
                         gradientDuoTone="purpleToBlue"
                         size="sm"
-                        onClick={handleToggle}
+                        onClick={handleOpenInNewTab}
                         className="flex items-center text-sm font-semibold rounded-lg"
                     >
-                        {isInteractive ? (
-                            <>
-                                <FaTimes className="mr-2" /> Close Editor
-                            </>
-                        ) : (
-                            <>
-                                <FaPlayCircle className="mr-2" /> Try it Yourself
-                            </>
-                        )}
+                        <FaPlayCircle className="mr-2" /> Try it Yourself
                     </Button>
                 </motion.div>
             </div>
 
-            <AnimatePresence mode="wait">
-                {isInteractive ? (
-                    <motion.div
-                        key="interactive"
-                        variants={contentVariants}
-                        initial="hidden"
-                        animate="visible"
-                        exit="exit"
-                        className="pt-6"
-                    >
-                        <CodeEditor
-                            initialCode={{ [language]: initialCode }}
-                            language={language}
-                        />
-                    </motion.div>
-                ) : (
-                    <motion.div
-                        key="static"
-                        variants={contentVariants}
-                        initial="hidden"
-                        animate="visible"
-                        exit="exit"
-                        className="pt-6"
-                    >
-                        <div className="w-full relative group">
-                            <pre className={`p-5 rounded-lg bg-gray-900 text-white language-${language} overflow-x-auto text-sm shadow-inner`}>
-                                <code dangerouslySetInnerHTML={{ __html: initialCode }} />
-                            </pre>
-                            <motion.div
-                                {...motionWrapperProps}
-                                className="absolute bottom-4 right-4 z-10"
-                            >
-                                <Button size="xs" outline gradientDuoTone="purpleToBlue" onClick={handleOpenInNewTab}>
-                                    <FaExternalLinkAlt className="mr-1" />
-                                    Open in new tab
-                                </Button>
-                            </motion.div>
-                        </div>
-                    </motion.div>
-                )}
-            </AnimatePresence>
+            <div className="pt-6">
+                <pre className={`p-5 rounded-lg bg-gray-900 text-white language-${language} overflow-x-auto text-sm shadow-inner`}>
+                    <code dangerouslySetInnerHTML={{ __html: initialCode }} />
+                </pre>
+            </div>
         </motion.div>
     );
 }
+

--- a/client/src/pages/SingleTutorialPage.jsx
+++ b/client/src/pages/SingleTutorialPage.jsx
@@ -363,7 +363,7 @@ export default function SingleTutorialPage() {
                 const languageFromClass = codeNode.attribs['class']?.replace('language-', '');
                 const defaultLanguage = categoryToLanguageMap[tutorial.category];
                 const language = languageFromClass || defaultLanguage || 'javascript';
-                return <InteractiveCodeBlock initialCode={codeText} language={language} />;
+                return <InteractiveCodeBlock initialCode={codeText} language={language} expectedOutput={activeChapter?.expectedOutput || ''} />;
             }
             if (domNode.type === 'tag' && domNode.name === 'img') {
                 return (


### PR DESCRIPTION
## Summary
- launch Try It page in a new tab from interactive code blocks
- forward expected output and expose Show Answer toggle in the editor

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68b2a3dbaa38832882b40ce86bb274bb