### PR TITLE
fix: sync code editor theme with app theme

### DIFF
--- a/client/src/components/CodeEditor.jsx
+++ b/client/src/components/CodeEditor.jsx
@@ -109,6 +109,14 @@ export default function CodeEditor({ initialCode = {}, language = 'html', expect
     const [showSettings, setShowSettings] = useState(false);
     const [editorWidth, setEditorWidth] = useState(50);
 
+    // Keep the Monaco editor theme in sync with the application theme
+    useEffect(() => {
+        setEditorOptions((prev) => ({
+            ...prev,
+            theme: theme === 'dark' ? 'vs-dark' : 'vs-light',
+        }));
+    }, [theme]);
+
     const handleCodeChange = (newCode) => {
         setCodes(prevCodes => ({
             ...prevCodes,


### PR DESCRIPTION
## Summary
- ensure Monaco-based code editor reacts to global theme changes so the editor switches between light and dark modes accordingly

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68b2d951c88c8321a0be35ffb0697ce8