### PR TITLE
Handle underscores in slug generation

### DIFF
--- a/api/utils/slug.js
+++ b/api/utils/slug.js
@@ -4,6 +4,7 @@
  * The function performs the following operations:
  * - trims surrounding whitespace
  * - converts all characters to lower case
+ * - converts underscores to hyphens
  * - removes any character that is not alphanumeric, a space or a hyphen
  * - replaces consecutive whitespace characters with a single hyphen
  * - collapses multiple hyphens into one
@@ -24,6 +25,8 @@ export function generateSlug(title) {
 
     return trimmed
         .toLowerCase()
+        // Treat underscores as hyphens for word separation
+        .replace(/_/g, '-')
         // Remove all characters except letters, numbers, spaces and hyphens
         .replace(/[^a-z0-9\s-]/g, '')
         // Convert remaining whitespace to hyphens

--- a/api/utils/slug.test.js
+++ b/api/utils/slug.test.js
@@ -12,6 +12,11 @@ test('generateSlug removes non-alphanumeric characters', () => {
     assert.strictEqual(slug, 'react-nodejs-basics');
 });
 
+test('generateSlug converts underscores to hyphens', () => {
+    const slug = generateSlug('Hello_world_again');
+    assert.strictEqual(slug, 'hello-world-again');
+});
+
 test('generateSlug collapses whitespace and trims hyphens', () => {
     const slug = generateSlug('  Multiple   Spaces -- and symbols!!!  ');
     assert.strictEqual(slug, 'multiple-spaces-and-symbols');


### PR DESCRIPTION
## Summary
- treat underscores as hyphens when generating slugs
- add regression test for underscore handling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68b328eeb6c483218ed485c4d230d26f