### PR TITLE
Fix xterm viewport errors when TerminalPane is hidden

### DIFF
--- a/client/src/components/TerminalPane.jsx
+++ b/client/src/components/TerminalPane.jsx
@@ -23,7 +23,9 @@ export default function TerminalPane({
                 ? { background: '#1f2937', foreground: '#f3f4f6' }
                 : { background: '#ffffff', foreground: '#1f2937' },
         });
-        terminalRef.current.open(containerRef.current);
+        if (containerRef.current) {
+            terminalRef.current.open(containerRef.current);
+        }
         return () => terminalRef.current.dispose();
     }, []);
 
@@ -80,16 +82,18 @@ export default function TerminalPane({
                     </Button>
                 </div>
             </div>
-            {isOpen && (
-                <div className="flex-1 relative rounded-md overflow-hidden bg-white dark:bg-gray-800">
-                    <div ref={containerRef} className="absolute inset-0" />
-                    {isRunning && (
-                        <div className="absolute inset-0 flex items-center justify-center text-gray-400">
-                            <Spinner size="sm" /> <span className="ml-2">Running...</span>
-                        </div>
-                    )}
-                </div>
-            )}
+            <div
+                className={`flex-1 relative rounded-md overflow-hidden bg-white dark:bg-gray-800 ${
+                    isOpen ? '' : 'hidden'
+                }`}
+            >
+                <div ref={containerRef} className="absolute inset-0" />
+                {isRunning && (
+                    <div className="absolute inset-0 flex items-center justify-center text-gray-400">
+                        <Spinner size="sm" /> <span className="ml-2">Running...</span>
+                    </div>
+                )}
+            </div>
         </div>
     );
 }


### PR DESCRIPTION
## Summary
- keep TerminalPane mounted and hide via CSS to preserve xterm viewport
- guard terminal open with null check on container element

## Testing
- `npm test`
- `npm run lint --prefix client` (fails: Spinner defined but unused, etc.)
- `npm run build --prefix client` (fails: Rollup failed to resolve import "xterm")

------
https://chatgpt.com/codex/tasks/task_b_68b32d5abaec83218fcf792ec7b9044b