### PR TITLE
Allow admins to update any user

### DIFF
--- a/api/controllers/user.controller.js
+++ b/api/controllers/user.controller.js
@@ -8,7 +8,11 @@ export const test = (req, res) => {
 
 // --- Upgraded updateUser Function ---
 export const updateUser = async (req, res, next) => {
-  if (req.user.id !== req.params.userId) {
+  // Allow administrators to update any user while restricting regular users
+  // to only update their own account. The previous implementation blocked
+  // admins from updating other users, which is inconsistent with the
+  // authorization logic used elsewhere (e.g. deleteUser).
+  if (!req.user.isAdmin && req.user.id !== req.params.userId) {
     return next(errorHandler(403, 'You are not allowed to update this user'));
   }
 

--- a/api/controllers/user.controller.test.js
+++ b/api/controllers/user.controller.test.js
@@ -1,0 +1,58 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { updateUser } from './user.controller.js';
+import User from '../models/user.model.js';
+
+// Helper to create a mock request, response and next function
+function createMockResponse() {
+  return {
+    statusCode: null,
+    body: null,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.body = payload;
+      return this;
+    },
+  };
+}
+
+test('admin users can update other user accounts', async () => {
+  // Save original method to restore later
+  const originalFindById = User.findById;
+
+  // Mock the database call to findById
+  User.findById = async () => ({
+    username: 'oldname',
+    email: 'user@example.com',
+    profilePicture: 'pic.png',
+    _doc: { username: 'oldname', email: 'user@example.com', profilePicture: 'pic.png', password: 'hashed' },
+    async save() {
+      // Simulate mongoose save updating the _doc property
+      this._doc = { username: this.username, email: this.email, profilePicture: this.profilePicture, password: 'hashed' };
+      return this;
+    },
+  });
+
+  const req = {
+    user: { id: 'adminId', isAdmin: true },
+    params: { userId: 'targetUser' },
+    body: { username: 'newname' },
+  };
+  const res = createMockResponse();
+  let nextErr = null;
+  const next = (err) => { nextErr = err; };
+
+  await updateUser(req, res, next);
+
+  assert.equal(nextErr, null, 'next should not receive an error');
+  assert.equal(res.statusCode, 200);
+  assert.equal(res.body.username, 'newname');
+  assert.ok(!('password' in res.body), 'response should not expose password');
+
+  // Restore original method
+  User.findById = originalFindById;
+});
+


### PR DESCRIPTION
## Summary
- Permit administrators to update other users' profiles instead of being blocked
- Add unit test covering admin update logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68b390e103548322a2fbc482e9f34753