### PR TITLE
Add back-to-top button and smooth scroll

### DIFF
--- a/client/src/components/BackToTopButton.jsx
+++ b/client/src/components/BackToTopButton.jsx
@@ -1,0 +1,32 @@
+import { useEffect, useState } from 'react';
+import { FaArrowUp } from 'react-icons/fa';
+
+/**
+ * Displays a floating button that scrolls the window back to the top
+ * when clicked. The button appears after the user scrolls down the page.
+ */
+export default function BackToTopButton() {
+    const [isVisible, setIsVisible] = useState(false);
+
+    useEffect(() => {
+        const handleScroll = () => {
+            setIsVisible(window.scrollY > 300);
+        };
+        window.addEventListener('scroll', handleScroll);
+        return () => window.removeEventListener('scroll', handleScroll);
+    }, []);
+
+    const scrollToTop = () => {
+        window.scrollTo({ top: 0, behavior: 'smooth' });
+    };
+
+    return (
+        <button
+            onClick={scrollToTop}
+            aria-label="Scroll to top"
+            className={`fixed bottom-8 right-8 z-50 rounded-full bg-purple-600 p-3 text-white shadow-lg transition-opacity duration-300 hover:bg-purple-700 focus:outline-none focus:ring-2 focus:ring-purple-300 ${isVisible ? 'opacity-100' : 'opacity-0 pointer-events-none'}`}
+        >
+            <FaArrowUp />
+        </button>
+    );
+}

--- a/client/src/components/MainLayout.jsx
+++ b/client/src/components/MainLayout.jsx
@@ -2,6 +2,7 @@ import { Outlet } from 'react-router-dom';
 import Header from './Header';
 import Footer from './Footer';
 import ScrollToTop from './ScrollToTop';
+import BackToTopButton from './BackToTopButton';
 
 /**
  * Renders the common layout for the application, including the
@@ -16,6 +17,7 @@ export default function MainLayout() {
             <main>
                 <Outlet />
             </main>
+            <BackToTopButton />
             <Footer />
         </>
     );

--- a/client/src/components/ScrollToTop.jsx
+++ b/client/src/components/ScrollToTop.jsx
@@ -4,7 +4,7 @@ import { useLocation } from 'react-router-dom';
 const ScrollToTop = () => {
   const { pathname } = useLocation();
   useEffect(() => {
-    window.scrollTo(0, 0);
+    window.scrollTo({ top: 0, behavior: 'smooth' });
   }, [pathname]);
   return null;
 };


### PR DESCRIPTION
## Summary
- introduce a floating "back to top" button that appears after scrolling and smoothly returns users to the top
- scroll transitions now animate smoothly when navigating between routes

## Testing
- `npm test`
- `npm run lint --prefix client` *(fails: ESLint configuration missing; install attempt blocked by 403 from registry)*

------
https://chatgpt.com/codex/tasks/task_b_68b3949777a88322a7ca07244125ed85