### PR TITLE
Remove unused bcrypt import and test user authorization

### DIFF
--- a/api/controllers/user.controller.js
+++ b/api/controllers/user.controller.js
@@ -1,4 +1,3 @@
-import bcryptjs from 'bcryptjs';
 import { errorHandler } from '../utils/error.js';
 import User from '../models/user.model.js';
 

--- a/api/controllers/user.controller.test.js
+++ b/api/controllers/user.controller.test.js
@@ -56,3 +56,20 @@ test('admin users can update other user accounts', async () => {
   User.findById = originalFindById;
 });
 
+test('non-admin users cannot update other user accounts', async () => {
+  const req = {
+    user: { id: 'user1', isAdmin: false },
+    params: { userId: 'otherUser' },
+    body: { username: 'newname' },
+  };
+  const res = createMockResponse();
+  let nextErr = null;
+  const next = (err) => { nextErr = err; };
+
+  await updateUser(req, res, next);
+
+  assert.ok(nextErr, 'next should receive an error');
+  assert.equal(nextErr.statusCode, 403);
+  assert.equal(nextErr.message, 'You are not allowed to update this user');
+});
+


### PR DESCRIPTION
## Summary
- clean up `updateUser` controller by removing unused bcrypt dependency
- add test ensuring non-admin users cannot update other accounts

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68b3a5601b788322ab86c053b8d7443f