### PR TITLE
chore: improve naming clarity

### DIFF
--- a/api/controllers/user.controller.js
+++ b/api/controllers/user.controller.js
@@ -1,7 +1,8 @@
 import { errorHandler } from '../utils/error.js';
 import User from '../models/user.model.js';
 
-export const test = (req, res) => {
+// More descriptive name for API health-check endpoint
+export const checkApiHealth = (req, res) => {
   res.json({ message: 'API is working!' });
 };
 
@@ -39,8 +40,9 @@ export const updateUser = async (req, res, next) => {
     // This automatically handles validation and password hashing as defined in the model
     const updatedUser = await userToUpdate.save();
 
-    const { password, ...rest } = updatedUser._doc;
-    res.status(200).json(rest);
+    // Remove password before returning the user data
+    const { password, ...userWithoutPassword } = updatedUser._doc;
+    res.status(200).json(userWithoutPassword);
   } catch (error) {
     // Mongoose validation errors will be caught here
     next(error);

--- a/api/routes/user.route.js
+++ b/api/routes/user.route.js
@@ -4,14 +4,15 @@ import {
   getUser,
   getUsers,
   signout,
-  test,
+  checkApiHealth,
   updateUser,
 } from '../controllers/user.controller.js';
 import { verifyToken } from '../utils/verifyUser.js';
 
 const router = express.Router();
 
-router.get('/test', test);
+// Endpoint for verifying the API is responsive
+router.get('/health', checkApiHealth);
 router.put('/update/:userId', verifyToken, updateUser);
 router.delete('/delete/:userId', verifyToken, deleteUser);
 router.post('/signout', signout);


### PR DESCRIPTION
## Summary
- rename generic `test` API endpoint to `checkApiHealth`
- clarify user update response by using `userWithoutPassword`
- route `/health` now provides API health check

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68b3a916d49483228ced836313d2b107