### PR TITLE
Fix whitespace handling in required field validation

### DIFF
--- a/api/utils/validateRequiredFields.js
+++ b/api/utils/validateRequiredFields.js
@@ -8,7 +8,11 @@ import { errorHandler } from './error.js';
  */
 export function validateRequiredFields(fields) {
   const missing = Object.entries(fields)
-    .filter(([, value]) => value === undefined || value === null || value === '')
+    .filter(([, value]) =>
+      value === undefined ||
+      value === null ||
+      (typeof value === 'string' && value.trim() === '')
+    )
     .map(([key]) => key);
 
   if (missing.length > 0) {

--- a/api/utils/validateRequiredFields.test.js
+++ b/api/utils/validateRequiredFields.test.js
@@ -7,6 +7,12 @@ describe('validateRequiredFields', () => {
     );
   });
 
+  test('treats whitespace-only strings as missing', () => {
+    expect(() =>
+      validateRequiredFields({ email: '   ', password: '123' }),
+    ).toThrow('email is required');
+  });
+
   test('does not throw when all fields are provided', () => {
     expect(() => validateRequiredFields({ email: 'a', password: '123' })).not.toThrow();
   });


### PR DESCRIPTION
## Summary
- handle whitespace-only strings as missing in `validateRequiredFields`
- add regression test for whitespace-only fields

## Testing
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_b_68b416cc66f4832a955076cf1d1d5004