### PR TITLE
feat: add copy button for code blocks

### DIFF
--- a/client/src/Tiptap.css
+++ b/client/src/Tiptap.css
@@ -97,6 +97,7 @@
     font-family: 'JetBrainsMono', monospace;
     padding: 0.75rem 1rem;
     border-radius: 0.5rem;
+    position: relative;
 }
 
 .tiptap pre code {
@@ -104,6 +105,25 @@
     padding: 0;
     background: none;
     font-size: 0.8rem;
+}
+
+.code-copy-btn {
+    position: absolute;
+    top: 0.25rem;
+    right: 0.25rem;
+    background: rgba(0, 0, 0, 0.6);
+    color: #fff;
+    border: none;
+    padding: 0.25rem 0.5rem;
+    font-size: 0.75rem;
+    border-radius: 0.25rem;
+    cursor: pointer;
+    opacity: 0;
+    transition: opacity 0.2s ease-in-out;
+}
+
+.tiptap pre:hover .code-copy-btn {
+    opacity: 1;
 }
 
 .tiptap img {

--- a/client/src/components/TiptapEditor.jsx
+++ b/client/src/components/TiptapEditor.jsx
@@ -107,6 +107,31 @@ export default function TiptapEditor({ content, onChange, placeholder }) {
         }
     }, [content, editor]);
 
+    useEffect(() => {
+        if (!editor) return;
+
+        const addCopyButtons = () => {
+            const blocks = editor.view.dom.querySelectorAll('pre');
+            blocks.forEach((block) => {
+                if (block.querySelector('.code-copy-btn')) return;
+                const button = document.createElement('button');
+                button.innerText = 'Copy';
+                button.className = 'code-copy-btn';
+                button.addEventListener('click', () => {
+                    const code = block.querySelector('code')?.textContent || '';
+                    navigator.clipboard.writeText(code);
+                });
+                block.appendChild(button);
+            });
+        };
+
+        addCopyButtons();
+        editor.on('update', addCopyButtons);
+        return () => {
+            editor.off('update', addCopyButtons);
+        };
+    }, [editor]);
+
     const addYoutubeVideo = useCallback(() => {
         const url = prompt('Enter YouTube URL');
         if (url && editor) {


### PR DESCRIPTION
## Summary
- add copy-to-clipboard buttons to code blocks in the Tiptap editor
- style code blocks to reveal copy button on hover

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_68b4195f0608832a9147c7b874f8f3ed