### PR TITLE
feat: expand code editor with file explorer and terminal improvements

### DIFF
--- a/client/src/components/TerminalPane.jsx
+++ b/client/src/components/TerminalPane.jsx
@@ -13,7 +13,6 @@ export default function TerminalPane({
 }) {
     const containerRef = useRef(null);
     const terminalRef = useRef(null);
-    const prevOutputRef = useRef('');
     const [isOpen, setIsOpen] = useState(true);
 
     useEffect(() => {
@@ -41,20 +40,15 @@ export default function TerminalPane({
         if (!terminalRef.current) return;
         if (!output && !error) {
             terminalRef.current.clear();
-            prevOutputRef.current = '';
             return;
         }
+        const timestamp = new Date().toLocaleTimeString();
         const text = error ? `\x1b[31m${error}\x1b[0m` : output;
-        const newText = text.slice(prevOutputRef.current.length);
-        if (newText) {
-            terminalRef.current.write(newText.replace(/\n/g, '\r\n'));
-            prevOutputRef.current = text;
-        }
+        terminalRef.current.writeln(`[${timestamp}] ${text}`.replace(/\n/g, '\r\n'));
     }, [output, error]);
 
     const handleClear = () => {
         terminalRef.current?.clear();
-        prevOutputRef.current = '';
         onClear && onClear();
     };
 


### PR DESCRIPTION
## Summary
- enhance Monaco autocompletion with extra JS, CSS snippets
- add file explorer panel for managing multiple files per language
- show timestamps and clear button in terminal output

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_68b438d0b07c832abd4756991f5766e4