### PR TITLE
feat: add code editor keyboard shortcuts

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ ScientistShieldOne is a MERN-stack application for sharing knowledge and practic
 ## Features
 - **Tutorials:** Browse and read educational content on various topics.
 - **Quizzes:** Evaluate understanding through interactive quizzes.
-- **Code Editor:** Try out code snippets directly in the browser.
+- **Code Editor:** Try out code snippets directly in the browser with handy keyboard shortcuts (e.g., `Ctrl+Enter` to run, `Ctrl+S` to save, `Ctrl+Shift+F` to format).
 
 ## Directory Structure
 - `api/` – Node.js/Express backend including routes, controllers, and models.

--- a/client/src/components/CodeEditor.jsx
+++ b/client/src/components/CodeEditor.jsx
@@ -365,6 +365,25 @@ export default function CodeEditor({ initialCode = {}, language = 'html', expect
         }
     };
 
+    useEffect(() => {
+        const handleKeyDown = (e) => {
+            if ((e.ctrlKey || e.metaKey) && e.key === 'Enter') {
+                e.preventDefault();
+                runCode();
+            }
+            if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === 's') {
+                e.preventDefault();
+                saveSnippet();
+            }
+            if ((e.ctrlKey || e.metaKey) && e.shiftKey && e.key.toLowerCase() === 'f') {
+                e.preventDefault();
+                formatCode();
+            }
+        };
+        window.addEventListener('keydown', handleKeyDown);
+        return () => window.removeEventListener('keydown', handleKeyDown);
+    }, [runCode, saveSnippet, formatCode]);
+
     return (
         <div className={`flex flex-col p-4 bg-gray-50 dark:bg-gray-900 shadow-xl ${isFullScreen ? 'fixed inset-0 z-50 h-screen w-screen rounded-none' : 'h-[90vh] md:h-[800px] rounded-lg'}`}>
             <div className="flex flex-col sm:flex-row justify-between items-center p-2 mb-4 gap-4">
@@ -467,6 +486,7 @@ export default function CodeEditor({ initialCode = {}, language = 'html', expect
                             onClick={runCode}
                             isProcessing={isRunning}
                             disabled={isRunning}
+                            title="Run Code (Ctrl+Enter)"
                         >
                             <FaPlay className="mr-2 h-4 w-4" /> Run Code
                         </Button>
@@ -483,7 +503,7 @@ export default function CodeEditor({ initialCode = {}, language = 'html', expect
                           whileHover={{ scale: 1.05 }}
                           whileTap={{ scale: 0.95 }}
                       >
-                          <Button outline gradientDuoTone="purpleToBlue" onClick={copyCurrentCode}>
+                          <Button outline gradientDuoTone="purpleToBlue" onClick={copyCurrentCode} title="Copy Code">
                               <FaCopy className="mr-2 h-4 w-4" /> Copy Code
                           </Button>
                       </motion.div>
@@ -491,7 +511,7 @@ export default function CodeEditor({ initialCode = {}, language = 'html', expect
                           whileHover={{ scale: 1.05 }}
                           whileTap={{ scale: 0.95 }}
                       >
-                          <Button outline gradientDuoTone="purpleToBlue" onClick={formatCode}>
+                          <Button outline gradientDuoTone="purpleToBlue" onClick={formatCode} title="Format Code (Ctrl+Shift+F)">
                               <FaMagic className="mr-2 h-4 w-4" /> Format
                           </Button>
                       </motion.div>
@@ -499,7 +519,7 @@ export default function CodeEditor({ initialCode = {}, language = 'html', expect
                           whileHover={{ scale: 1.05 }}
                           whileTap={{ scale: 0.95 }}
                       >
-                          <Button outline gradientDuoTone="purpleToBlue" onClick={saveSnippet} isProcessing={isSaving} disabled={isSaving}>
+                          <Button outline gradientDuoTone="purpleToBlue" onClick={saveSnippet} isProcessing={isSaving} disabled={isSaving} title="Save & Share (Ctrl+S)">
                               <FaSave className="mr-2 h-4 w-4" /> Save & Share
                           </Button>
                       </motion.div>


### PR DESCRIPTION
## Summary
- add keyboard shortcuts for running, saving, and formatting code
- expose shortcuts via button tooltips and docs

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: 403 Forbidden to npm registry)*

------
https://chatgpt.com/codex/tasks/task_b_68b457dd25d0832a87003c85bdac1883