### PR TITLE
fix: avoid xterm usage after disposal

### DIFF
--- a/client/src/components/TerminalPane.jsx
+++ b/client/src/components/TerminalPane.jsx
@@ -26,7 +26,11 @@ export default function TerminalPane({
         if (containerRef.current) {
             terminalRef.current.open(containerRef.current);
         }
-        return () => terminalRef.current.dispose();
+        return () => {
+            // Ensure we don't attempt to interact with a disposed terminal
+            terminalRef.current?.dispose();
+            terminalRef.current = null;
+        };
     }, []);
 
     useEffect(() => {


### PR DESCRIPTION
## Summary
- prevent attempts to use a disposed xterm instance by nulling the ref after cleanup

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@babel%2fpreset-env)*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_b_68b476e01ff8832aaefe9ea9b4e32a85