### PR TITLE
feat: add onboarding tour and social login

### DIFF
--- a/api/controllers/auth.controller.js
+++ b/api/controllers/auth.controller.js
@@ -105,3 +105,39 @@ export const google = async (req, res, next) => {
     next(error);
   }
 };
+
+export const github = async (req, res, next) => {
+  const { email, name, githubPhotoUrl } = req.body;
+  try {
+    const user = await User.findOne({ email });
+    if (user) {
+      const token = signToken({ id: user._id, isAdmin: user.isAdmin });
+      const { password: _password, ...rest } = user._doc;
+      return res
+          .status(200)
+          .cookie('access_token', token, { httpOnly: true })
+          .json(rest);
+    }
+    const generatedPassword =
+        Math.random().toString(36).slice(-8) +
+        Math.random().toString(36).slice(-8);
+    const hashedPassword = await bcryptjs.hash(generatedPassword, 10);
+    const newUser = new User({
+      username:
+          name.toLowerCase().split(' ').join('') +
+          Math.random().toString(9).slice(-4),
+      email,
+      password: hashedPassword,
+      profilePicture: githubPhotoUrl,
+    });
+    await newUser.save();
+    const token = signToken({ id: newUser._id, isAdmin: newUser.isAdmin });
+    const { password: _password, ...rest } = newUser._doc;
+    res
+        .status(200)
+        .cookie('access_token', token, { httpOnly: true })
+        .json(rest);
+  } catch (error) {
+    next(error);
+  }
+};

--- a/api/controllers/user.controller.js
+++ b/api/controllers/user.controller.js
@@ -35,6 +35,12 @@ export const updateUser = async (req, res, next) => {
     if (req.body.profilePicture) {
       userToUpdate.profilePicture = req.body.profilePicture;
     }
+    if (req.body.bio !== undefined) {
+      userToUpdate.bio = req.body.bio;
+    }
+    if (req.body.profileCompleted !== undefined) {
+      userToUpdate.profileCompleted = req.body.profileCompleted;
+    }
 
     // Using user.save() will trigger the Mongoose pre-save middleware
     // This automatically handles validation and password hashing as defined in the model

--- a/api/models/user.model.js
+++ b/api/models/user.model.js
@@ -28,7 +28,16 @@ const userSchema = new mongoose.Schema(
             default:
                 'https://cdn.pixabay.com/photo/2015/10/05/22/37/blank-profile-picture-973460_960_720.png',
         },
+        bio: {
+            type: String,
+            default: '',
+            trim: true,
+        },
         isAdmin: {
+            type: Boolean,
+            default: false,
+        },
+        profileCompleted: {
             type: Boolean,
             default: false,
         },

--- a/api/routes/auth.route.js
+++ b/api/routes/auth.route.js
@@ -1,10 +1,11 @@
 import express from 'express';
-import { google, signin, signup } from '../controllers/auth.controller.js';
+import { google, signin, signup, github } from '../controllers/auth.controller.js';
 
 const router = express.Router();
 
 router.post('/signup', signup);
 router.post('/signin', signin);
 router.post('/google', google);
+router.post('/github', github);
 
 export default router;

--- a/client/package.json
+++ b/client/package.json
@@ -79,7 +79,9 @@
     "redux-persist": "^6.0.0",
     "tsparticles-slim": "^2.12.0",
     "xterm": "^5.3.0",
-    "zod": "^4.0.5"
+    "zod": "^4.0.5",
+    "intro.js": "^7.2.0",
+    "intro.js-react": "^1.1.2"
   },
   "devDependencies": {
     "@tailwindcss/line-clamp": "^0.4.4",

--- a/client/src/components/DashProfile.jsx
+++ b/client/src/components/DashProfile.jsx
@@ -1,5 +1,5 @@
 // client/src/components/DashProfile.jsx
-import { Alert, Button, FileInput, Select, TextInput, Spinner, Modal } from 'flowbite-react';
+import { Alert, Button, FileInput, Select, TextInput, Textarea, Spinner, Modal } from 'flowbite-react';
 import { useEffect, useRef, useState } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import { CircularProgressbar } from 'react-circular-progressbar';
@@ -89,7 +89,7 @@ export default function DashProfile() {
       const res = await fetch(`/api/user/update/${currentUser._id}`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(formData),
+        body: JSON.stringify({ ...formData, profileCompleted: true }),
       });
       const data = await res.json();
       if (!res.ok) {
@@ -176,6 +176,7 @@ export default function DashProfile() {
           <TextInput id='username' type='text' placeholder='username' defaultValue={currentUser.username} onChange={handleChange} />
           <TextInput id='email' type='email' placeholder='email' defaultValue={currentUser.email} onChange={handleChange} />
           <TextInput id='password' type='password' placeholder='password' onChange={handleChange} />
+          <Textarea id='bio' placeholder='bio' defaultValue={currentUser.bio} onChange={handleChange} />
 
           <Button type='submit' gradientDuoTone='purpleToBlue' outline disabled={loading || isUploading}>
             {loading ? 'Loading...' : 'Update'}

--- a/client/src/components/Header.jsx
+++ b/client/src/components/Header.jsx
@@ -81,8 +81,11 @@ function CommandMenu({ isOpen, onClose }) {
 
 const navLinks = [
   { label: 'Home', path: '/' },
-  { label: 'About', path: '/about' },
+  { label: 'Tutorials', path: '/tutorials', id: 'tutorial-link' },
+  { label: 'Quizzes', path: '/quizzes', id: 'quiz-link' },
+  { label: 'Code Editor', path: '/tryit', id: 'editor-link' },
   { label: 'Projects', path: '/projects' },
+  { label: 'About', path: '/about' },
 ];
 
 
@@ -209,7 +212,7 @@ export default function Header() {
                   const isActive = path === link.path;
                   return (
                       <motion.div variants={navItemVariants} key={link.path}>
-                        <Link to={link.path} className='relative px-3 py-2 text-sm text-gray-700 dark:text-gray-300 hover:text-cyan-500 dark:hover:text-cyan-400 transition-colors'>
+                        <Link id={link.id} to={link.path} className='relative px-3 py-2 text-sm text-gray-700 dark:text-gray-300 hover:text-cyan-500 dark:hover:text-cyan-400 transition-colors'>
                           {isActive && (<motion.span layoutId='active-pill' className='absolute inset-0 bg-gray-100 dark:bg-gray-700 rounded-full' style={{ borderRadius: 9999 }} transition={{ type: 'spring', stiffness: 300, damping: 30 }} />)}
                           <span className='relative z-10'>{link.label}</span>
                         </Link>
@@ -280,7 +283,7 @@ export default function Header() {
                 <Navbar.Toggle />
               </div>
               <Navbar.Collapse>
-                {navLinks.map((link) => (<Navbar.Link active={path === link.path} as={'div'} key={link.path} className="lg:hidden"><Link to={link.path}>{link.label}</Link></Navbar.Link>))}
+                {navLinks.map((link) => (<Navbar.Link active={path === link.path} as={'div'} key={link.path} className="lg:hidden"><Link id={link.id} to={link.path}>{link.label}</Link></Navbar.Link>))}
               </Navbar.Collapse>
             </Navbar>
           </div>

--- a/client/src/components/MainLayout.jsx
+++ b/client/src/components/MainLayout.jsx
@@ -3,6 +3,8 @@ import Header from './Header';
 import Footer from './Footer';
 import ScrollToTop from './ScrollToTop';
 import BackToTopButton from './BackToTopButton';
+import Onboarding from './Onboarding';
+import ProfileCompletionPrompt from './ProfileCompletionPrompt';
 
 /**
  * Renders the common layout for the application, including the
@@ -16,6 +18,8 @@ export default function MainLayout() {
             <a href="#main-content" className="skip-link">Skip to main content</a>
             <ScrollToTop />
             <Header />
+            <Onboarding />
+            <ProfileCompletionPrompt />
             <main id="main-content">
                 <Outlet />
             </main>

--- a/client/src/components/OAuth.jsx
+++ b/client/src/components/OAuth.jsx
@@ -1,6 +1,6 @@
 import { Button } from 'flowbite-react';
-import { AiFillGoogleCircle } from 'react-icons/ai';
-import { GoogleAuthProvider, signInWithPopup, getAuth } from 'firebase/auth';
+import { AiFillGoogleCircle, AiFillGithub } from 'react-icons/ai';
+import { GoogleAuthProvider, GithubAuthProvider, signInWithPopup, getAuth } from 'firebase/auth';
 import { app } from '../firebase';
 import { useDispatch } from 'react-redux';
 import { signInSuccess } from '../redux/user/userSlice';
@@ -32,11 +32,42 @@ export default function OAuth() {
         } catch (error) {
             console.log(error);
         }
-    } 
-  return (
-    <Button type='button' gradientDuoTone='pinkToOrange' outline onClick={handleGoogleClick}>
-        <AiFillGoogleCircle className='w-6 h-6 mr-2'/>
-        Continue with Google
-    </Button>
-  )
+    }
+
+    const handleGithubClick = async () => {
+        const provider = new GithubAuthProvider();
+        provider.setCustomParameters({ allow_signup: 'false' });
+        try {
+            const results = await signInWithPopup(auth, provider);
+            const res = await fetch('/api/auth/github', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    name: results.user.displayName,
+                    email: results.user.email,
+                    githubPhotoUrl: results.user.photoURL,
+                }),
+            });
+            const data = await res.json();
+            if (res.ok) {
+                dispatch(signInSuccess(data));
+                navigate('/');
+            }
+        } catch (error) {
+            console.log(error);
+        }
+    };
+
+    return (
+        <div className='flex flex-col gap-2'>
+            <Button type='button' gradientDuoTone='pinkToOrange' outline onClick={handleGoogleClick}>
+                <AiFillGoogleCircle className='w-6 h-6 mr-2'/>
+                Continue with Google
+            </Button>
+            <Button type='button' gradientDuoTone='cyanToBlue' outline onClick={handleGithubClick}>
+                <AiFillGithub className='w-6 h-6 mr-2'/>
+                Continue with GitHub
+            </Button>
+        </div>
+    )
 }

--- a/client/src/components/Onboarding.jsx
+++ b/client/src/components/Onboarding.jsx
@@ -1,0 +1,34 @@
+import { useEffect, useState } from 'react';
+import { Steps } from 'intro.js-react';
+import 'intro.js/introjs.css';
+
+export default function Onboarding() {
+  const [enabled, setEnabled] = useState(false);
+  const steps = [
+    {
+      element: '#tutorial-link',
+      intro: 'Browse interactive tutorials here.',
+    },
+    {
+      element: '#quiz-link',
+      intro: 'Challenge yourself with quizzes.',
+    },
+    {
+      element: '#editor-link',
+      intro: 'Practice coding in the live editor.',
+    },
+  ];
+
+  useEffect(() => {
+    if (!localStorage.getItem('hasSeenOnboarding')) {
+      setEnabled(true);
+    }
+  }, []);
+
+  const handleExit = () => {
+    setEnabled(false);
+    localStorage.setItem('hasSeenOnboarding', 'true');
+  };
+
+  return <Steps enabled={enabled} steps={steps} initialStep={0} onExit={handleExit} />;
+}

--- a/client/src/components/ProfileCompletionPrompt.jsx
+++ b/client/src/components/ProfileCompletionPrompt.jsx
@@ -1,0 +1,38 @@
+import { Modal, Button } from 'flowbite-react';
+import { useEffect, useState } from 'react';
+import { useSelector } from 'react-redux';
+import { Link } from 'react-router-dom';
+
+export default function ProfileCompletionPrompt() {
+  const { currentUser } = useSelector((state) => state.user);
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    if (currentUser && !currentUser.profileCompleted) {
+      setOpen(true);
+    }
+  }, [currentUser]);
+
+  if (!currentUser) return null;
+
+  return (
+    <Modal show={open} onClose={() => setOpen(false)} popup>
+      <Modal.Header />
+      <Modal.Body>
+        <div className="text-center">
+          <h3 className="mb-5 text-lg font-normal text-gray-500 dark:text-gray-400">
+            Complete your profile to unlock personalized features.
+          </h3>
+          <div className="flex justify-center gap-4">
+            <Button color="gray" onClick={() => setOpen(false)}>
+              Later
+            </Button>
+            <Link to="/dashboard?tab=profile">
+              <Button>Complete now</Button>
+            </Link>
+          </div>
+        </div>
+      </Modal.Body>
+    </Modal>
+  );
+}


### PR DESCRIPTION
## Summary
- guide new users with intro.js onboarding tour
- add Google and GitHub OAuth flows and navigation links
- prompt users to complete profile with bio support

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@babel%2fpreset-env)*

------
https://chatgpt.com/codex/tasks/task_b_68b4edcbc754832aa9c2af7dd76e8c6f