### PR TITLE
feat: add jwt expiration and auth route test

### DIFF
--- a/api/controllers/auth.controller.js
+++ b/api/controllers/auth.controller.js
@@ -6,8 +6,9 @@ import jwt from 'jsonwebtoken';
 
 /**
  * Signs a JWT for the provided payload using the application's secret.
- * Throws an error when the secret is missing so it can be handled by the
- * route's error middleware.
+ * An expiration is included to reduce the risk of token replay and enforce
+ * re-authentication. The secret is read from the environment and an error is
+ * thrown if it is missing so callers can handle it consistently.
  *
  * @param {object} payload - Data to embed within the token.
  * @returns {string} Signed JSON Web Token.
@@ -18,7 +19,7 @@ const signToken = (payload) => {
     // Using the same error handler ensures consistent error responses
     throw errorHandler(500, 'JWT secret is missing');
   }
-  return jwt.sign(payload, secret);
+  return jwt.sign(payload, secret, { expiresIn: '1h' });
 };
 
 export const signup = async (req, res, next) => {
@@ -58,6 +59,9 @@ export const signin = async (req, res, next) => {
       .status(200)
       .cookie('access_token', token, {
         httpOnly: true,
+        secure: process.env.NODE_ENV === 'production',
+        sameSite: 'strict',
+        maxAge: 60 * 60 * 1000, // 1 hour
       })
       .json(rest);
   } catch (error) {
@@ -76,6 +80,9 @@ export const google = async (req, res, next) => {
           .status(200)
           .cookie('access_token', token, {
             httpOnly: true,
+            secure: process.env.NODE_ENV === 'production',
+            sameSite: 'strict',
+            maxAge: 60 * 60 * 1000,
           })
           .json(rest);
     }
@@ -99,6 +106,9 @@ export const google = async (req, res, next) => {
         .status(200)
         .cookie('access_token', token, {
           httpOnly: true,
+          secure: process.env.NODE_ENV === 'production',
+          sameSite: 'strict',
+          maxAge: 60 * 60 * 1000,
         })
         .json(rest);
   } catch (error) {
@@ -115,7 +125,12 @@ export const github = async (req, res, next) => {
       const { password: _password, ...rest } = user._doc;
       return res
           .status(200)
-          .cookie('access_token', token, { httpOnly: true })
+          .cookie('access_token', token, {
+            httpOnly: true,
+            secure: process.env.NODE_ENV === 'production',
+            sameSite: 'strict',
+            maxAge: 60 * 60 * 1000,
+          })
           .json(rest);
     }
     const generatedPassword =
@@ -135,7 +150,12 @@ export const github = async (req, res, next) => {
     const { password: _password, ...rest } = newUser._doc;
     res
         .status(200)
-        .cookie('access_token', token, { httpOnly: true })
+        .cookie('access_token', token, {
+          httpOnly: true,
+          secure: process.env.NODE_ENV === 'production',
+          sameSite: 'strict',
+          maxAge: 60 * 60 * 1000,
+        })
         .json(rest);
   } catch (error) {
     next(error);

--- a/api/index.js
+++ b/api/index.js
@@ -57,10 +57,6 @@ app.use(
 app.use(express.json());
 app.use(cookieParser());
 
-app.listen(PORT, () => {
-    console.log(`Server is running on port ${PORT}!`);
-});
-
 app.use('/api/user', userRoutes);
 app.use('/api/auth', authRoutes);
 app.use('/api/post', postRoutes);
@@ -91,3 +87,11 @@ app.use((err, req, res, next) => {
         message,
     });
 });
+
+if (process.env.NODE_ENV !== 'test') {
+    app.listen(PORT, () => {
+        console.log(`Server is running on port ${PORT}!`);
+    });
+}
+
+export default app;

--- a/api/routes/auth.route.test.js
+++ b/api/routes/auth.route.test.js
@@ -1,0 +1,62 @@
+/**
+ * @jest-environment node
+ */
+import express from 'express';
+import request from 'supertest';
+import authRouter from './auth.route.js';
+import User from '../models/user.model.js';
+import bcryptjs from 'bcryptjs';
+
+jest.mock('../models/user.model.js');
+jest.mock('bcryptjs');
+
+/**
+ * Creates an express app instance with the auth router mounted. This avoids
+ * starting the full server and allows isolated route testing.
+ */
+function createTestApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/auth', authRouter);
+  // Minimal error handler mirroring the production one
+  app.use((err, req, res, next) => {
+    const statusCode = err.statusCode || 500;
+    const message = err.message || 'Internal Server Error';
+    res.status(statusCode).json({ success: false, statusCode, message });
+  });
+  return app;
+}
+
+describe('Auth routes', () => {
+  let app;
+
+  beforeAll(() => {
+    app = createTestApp();
+  });
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('registers a user successfully', async () => {
+    bcryptjs.hash.mockResolvedValue('hashed');
+    User.prototype.save = jest.fn().mockResolvedValue();
+
+    const res = await request(app)
+      .post('/api/auth/signup')
+      .send({ username: 'test', email: 'test@example.com', password: 'password' });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toBe('Signup successful');
+    expect(User.prototype.save).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns 400 when fields are missing', async () => {
+    const res = await request(app)
+      .post('/api/auth/signup')
+      .send({});
+
+    expect(res.status).toBe(400);
+    expect(res.body.message).toMatch(/required/);
+  });
+});

--- a/api/utils/verifyUser.js
+++ b/api/utils/verifyUser.js
@@ -21,6 +21,9 @@ export const verifyToken = (req, res, next) => {
     } catch (error) {
         // It's helpful to log the error for debugging purposes.
         console.error('JWT Verification Error:', error.message);
+        if (error.name === 'TokenExpiredError') {
+            return next(errorHandler(401, 'Token expired'));
+        }
         return next(errorHandler(401, 'Unauthorized'));
     }
 };

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@testing-library/jest-dom": "^6.1.3",
     "@testing-library/react": "^14.0.0",
     "babel-jest": "^29.7.0",
-    "jest": "^29.7.0"
+    "jest": "^29.7.0",
+    "supertest": "^6.3.3"
   }
 }


### PR DESCRIPTION
## Summary
- add 1h expiration to issued JWTs and tighten cookie options
- handle expired tokens in middleware
- export Express app for tests and add supertest-based auth route tests

## Testing
- `npm install` (fails: 403 Forbidden - GET https://registry.npmjs.org/@babel%2fpreset-env)
- `npm test` (fails: jest: not found)


------
https://chatgpt.com/codex/tasks/task_b_68b50b23207483229c43c6de14a39cc2