### PR TITLE
feat: return 201 on signup

### DIFF
--- a/api/controllers/auth.controller.js
+++ b/api/controllers/auth.controller.js
@@ -33,7 +33,10 @@ export const signup = async (req, res, next) => {
       password: hashedPassword,
     });
     await newUser.save();
-    res.json('Signup successful');
+    // Return a 201 Created status to indicate that a new user resource was
+    // successfully created. This aligns the response with HTTP semantics and
+    // makes the behaviour consistent with other creation endpoints.
+    res.status(201).json('Signup successful');
   } catch (error) {
     next(error);
   }

--- a/api/routes/auth.route.test.js
+++ b/api/routes/auth.route.test.js
@@ -46,7 +46,9 @@ describe('Auth routes', () => {
       .post('/api/auth/signup')
       .send({ username: 'test', email: 'test@example.com', password: 'password' });
 
-    expect(res.status).toBe(200);
+    // The signup route now returns a 201 Created to signal a new user was
+    // successfully registered.
+    expect(res.status).toBe(201);
     expect(res.body).toBe('Signup successful');
     expect(User.prototype.save).toHaveBeenCalledTimes(1);
   });


### PR DESCRIPTION
## Summary
- use HTTP 201 for user creation
- adjust tests for signup route

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_68b7ba0b81ec8323a255fad7083bf74d