### PR TITLE
feat: add multi-language code visualizer

### DIFF
--- a/api/controllers/execution.controller.js
+++ b/api/controllers/execution.controller.js
@@ -1,0 +1,77 @@
+import vm from 'vm';
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+import fs from 'fs';
+import path from 'path';
+import { v4 as uuidv4 } from 'uuid';
+import { errorHandler } from '../utils/error.js';
+
+const execFileAsync = promisify(execFile);
+const __dirname = path.resolve();
+const TEMP_DIR = path.join(__dirname, 'temp');
+
+function instrumentJavaScript(code) {
+    const lines = code.split('\n');
+    const instrumented = lines
+        .map((line, idx) => {
+            const ln = idx + 1;
+            const sanitized = line.replace(/\b(let|const)\b/g, 'var');
+            return `__trace(${ln});\n${sanitized}`;
+        })
+        .join('\n');
+    return `(async () => { with (sandbox) {\n${instrumented}\n}})()`;
+}
+
+export const executeCode = async (req, res, next) => {
+    const { language, code } = req.body;
+    if (!language || !code) {
+        return next(errorHandler(400, 'Language and code are required.'));
+    }
+
+    if (language === 'javascript') {
+        const sandbox = {};
+        const events = [];
+        const context = vm.createContext({
+            sandbox,
+            console: {
+                log: (...args) => {
+                    events.push({ event: 'log', value: args.map(a => (typeof a === 'object' ? JSON.stringify(a) : String(a))).join(' ') });
+                },
+            },
+            __trace: (line) => {
+                events.push({ event: 'step', line, locals: { ...sandbox } });
+            },
+        });
+
+        try {
+            const script = new vm.Script(instrumentJavaScript(code));
+            await script.runInContext(context, { timeout: 1000 });
+            return res.status(200).json({ events, error: false });
+        } catch (err) {
+            events.push({ event: 'error', message: err.message });
+            return res.status(200).json({ events, error: true });
+        }
+    }
+
+    if (language === 'python') {
+        await fs.promises.mkdir(TEMP_DIR, { recursive: true });
+        const uniqueId = uuidv4();
+        const tracerPath = path.join(__dirname, 'api', 'utils', 'pythonTracer.py');
+        const filePath = path.join(TEMP_DIR, `${uniqueId}.py`);
+        try {
+            await fs.promises.writeFile(filePath, code);
+            const { stdout } = await execFileAsync('python3', [tracerPath, filePath], { timeout: 5000 });
+            const data = JSON.parse(stdout);
+            if (data.status === 'error') {
+                return res.status(200).json({ events: data.traces, output: data.stdout, error: true, message: data.error });
+            }
+            return res.status(200).json({ events: data.traces, output: data.stdout, error: false });
+        } catch (err) {
+            return res.status(200).json({ events: [], output: '', error: true, message: err.message });
+        } finally {
+            try { await fs.promises.unlink(filePath); } catch {}
+        }
+    }
+
+    return next(errorHandler(400, 'Unsupported language.'));
+};

--- a/api/index.js
+++ b/api/index.js
@@ -11,6 +11,7 @@ import quizRoutes from './routes/quiz.route.js';
 import codeSnippetRoutes from './routes/codeSnippet.route.js';
 import cppRoutes from './routes/cpp.route.js';
 import pythonRoutes from './routes/python.route.js';
+import executeRoutes from './routes/execute.route.js';
 
 import cookieParser from 'cookie-parser';
 import path from 'path';
@@ -66,6 +67,7 @@ app.use('/api/code-snippet', codeSnippetRoutes);
 app.use('/api', quizRoutes);
 app.use('/api/code', cppRoutes); // NEW: Use the new C++ route
 app.use('/api/code', pythonRoutes); // NEW: Use the new Python route
+app.use('/api', executeRoutes); // NEW: Unified execution route for JS/Python
 
 app.use(express.static(path.join(__dirname, '/client/dist')));
 

--- a/api/routes/execute.route.js
+++ b/api/routes/execute.route.js
@@ -1,0 +1,8 @@
+import express from 'express';
+import { executeCode } from '../controllers/execution.controller.js';
+
+const router = express.Router();
+
+router.post('/execute', executeCode);
+
+export default router;

--- a/api/utils/pythonTracer.py
+++ b/api/utils/pythonTracer.py
@@ -1,0 +1,46 @@
+import sys
+import json
+import io
+import runpy
+
+traces = []
+
+def tracefunc(frame, event, arg):
+    if event in ('call', 'line', 'return'):
+        traces.append({
+            'event': event,
+            'line': frame.f_lineno,
+            'locals': {k: repr(v) for k, v in frame.f_locals.items()}
+        })
+    return tracefunc
+
+def main(script_path):
+    with open(script_path, 'r') as f:
+        code = f.read()
+    stdout_buffer = io.StringIO()
+    sys.stdout = stdout_buffer
+    sys.settrace(tracefunc)
+    status = 'ok'
+    error = ''
+    try:
+        exec(compile(code, script_path, 'exec'), {})
+    except Exception as e:
+        status = 'error'
+        error = str(e)
+    finally:
+        sys.settrace(None)
+        sys.stdout = sys.__stdout__
+    result = {
+        'status': status,
+        'stdout': stdout_buffer.getvalue(),
+        'traces': traces
+    }
+    if status == 'error':
+        result['error'] = error
+    print(json.dumps(result))
+
+if __name__ == '__main__':
+    if len(sys.argv) < 2:
+        print(json.dumps({'status': 'error', 'error': 'No script path provided', 'traces': [], 'stdout': ''}))
+    else:
+        main(sys.argv[1])

--- a/client/package.json
+++ b/client/package.json
@@ -45,6 +45,7 @@
     "@tsparticles/react": "^3.0.0",
     "@tsparticles/slim": "^3.8.1",
     "axios": "^1.11.0",
+    "d3": "^7.9.0",
     "caniuse-lite": "^1.0.30001707",
     "dompurify": "^3.2.6",
     "firebase": "^10.7.1",

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -35,6 +35,7 @@ const UpdateQuiz = lazy(() => import('./pages/UpdateQuiz'));
 
 // NEW: Lazy load the Try it Yourself page
 const TryItPage = lazy(() => import('./pages/TryItPage'));
+const CodeVisualizer = lazy(() => import('./pages/CodeVisualizer'));
 
 // A fallback component to show while pages are loading
 const LoadingFallback = () => (
@@ -66,6 +67,7 @@ export default function App() {
 
                         {/* NEW: Try It Yourself Route */}
                         <Route path="tryit" element={<TryItPage />} />
+                        <Route path="visualizer" element={<CodeVisualizer />} />
 
                         {/* Private Routes also use the main layout */}
                         <Route element={<PrivateRoute />}>

--- a/client/src/components/ExecutionVisualizer.jsx
+++ b/client/src/components/ExecutionVisualizer.jsx
@@ -1,0 +1,68 @@
+// client/src/components/ExecutionVisualizer.jsx
+import { useState, useEffect, useRef } from 'react';
+import Editor from '@monaco-editor/react';
+import * as d3 from 'd3';
+import LanguageSelector from './LanguageSelector';
+
+export default function ExecutionVisualizer() {
+    const [language, setLanguage] = useState('javascript');
+    const [code, setCode] = useState('');
+    const [events, setEvents] = useState([]);
+    const [error, setError] = useState('');
+    const svgRef = useRef(null);
+
+    useEffect(() => {
+        const svg = d3.select(svgRef.current);
+        svg.selectAll('*').remove();
+        const width = 600;
+        const height = events.length * 30 + 20;
+        svg.attr('width', width).attr('height', height);
+        const g = svg.append('g');
+        events.forEach((e, i) => {
+            g.append('text')
+                .attr('x', 10)
+                .attr('y', 20 + i * 30)
+                .text(`L${e.line}: ${JSON.stringify(e.locals || {})}`)
+                .attr('font-size', '14px');
+        });
+    }, [events]);
+
+    const runCode = async () => {
+        setError('');
+        setEvents([]);
+        try {
+            const res = await fetch('/api/execute', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ language, code }),
+            });
+            const data = await res.json();
+            if (data.error) {
+                setError(data.message || 'Execution error');
+            }
+            setEvents(data.events || []);
+        } catch (e) {
+            setError('Network error');
+        }
+    };
+
+    return (
+        <div className="space-y-4">
+            <LanguageSelector selectedLanguage={language} setSelectedLanguage={setLanguage} languages={['javascript','python']} />
+            <Editor
+                height="40vh"
+                language={language}
+                value={code}
+                onChange={(value) => setCode(value)}
+            />
+            <button
+                onClick={runCode}
+                className="px-4 py-2 bg-purple-600 text-white rounded"
+            >
+                Run
+            </button>
+            {error && <div className="text-red-500">{error}</div>}
+            <svg ref={svgRef}></svg>
+        </div>
+    );
+}

--- a/client/src/components/LanguageSelector.jsx
+++ b/client/src/components/LanguageSelector.jsx
@@ -2,9 +2,9 @@
 import React from 'react';
 import { motion } from 'framer-motion';
 
-const languages = ['html', 'css', 'javascript', 'cpp', 'python'];
+const defaultLanguages = ['html', 'css', 'javascript', 'cpp', 'python'];
 
-export default function LanguageSelector({ selectedLanguage, setSelectedLanguage }) {
+export default function LanguageSelector({ selectedLanguage, setSelectedLanguage, languages = defaultLanguages }) {
     return (
         <motion.div
             layout

--- a/client/src/pages/CodeVisualizer.jsx
+++ b/client/src/pages/CodeVisualizer.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import ExecutionVisualizer from '../components/ExecutionVisualizer';
+
+export default function CodeVisualizer() {
+    return (
+        <div className="min-h-screen p-6 bg-gray-50 dark:bg-gray-900 text-gray-800 dark:text-gray-200">
+            <div className="max-w-4xl mx-auto">
+                <h1 className="text-3xl font-bold mb-4">Code Visualizer</h1>
+                <ExecutionVisualizer />
+            </div>
+        </div>
+    );
+}


### PR DESCRIPTION
## Summary
- add unified execution controller for Python and JavaScript with tracing support
- visualize execution flow with new D3-powered component and page
- allow language selector to accept custom language lists and register new /api/execute route

## Testing
- `npm install --prefix client` *(fails: 403 Forbidden - GET https://registry.npmjs.org/d3)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@babel%2fpreset-env)*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_b_68b7d5404bb48323b16c3fca0488cd9c