### PR TITLE
Add Code Visualizer link in header navigation

### DIFF
--- a/client/src/components/Header.jsx
+++ b/client/src/components/Header.jsx
@@ -84,6 +84,7 @@ const navLinks = [
   { label: 'Tutorials', path: '/tutorials', id: 'tutorial-link' },
   { label: 'Quizzes', path: '/quizzes', id: 'quiz-link' },
   { label: 'Code Editor', path: '/tryit', id: 'editor-link' },
+  { label: 'Code Visualizer', path: '/visualizer', id: 'visualizer-link' },
   { label: 'Projects', path: '/projects' },
   { label: 'About', path: '/about' },
 ];


### PR DESCRIPTION
## Summary
- Add Code Visualizer entry to the header navigation menu.

## Testing
- `npm test` *(fails: jest: not found)*
- `npm install` *(fails: 403 Forbidden retrieving @babel/preset-env)*

------
https://chatgpt.com/codex/tasks/task_b_68b7e5dd8fa883239d0cc25cb424701a