### PR TITLE
feat: instrument JS via AST and add safe tracing test

### DIFF
--- a/api/controllers/execution.controller.test.js
+++ b/api/controllers/execution.controller.test.js
@@ -1,0 +1,45 @@
+import vm from 'vm';
+import { instrumentJavaScript } from './execution.controller.js';
+
+function createContext(events) {
+  const sandbox = {};
+  return {
+    context: vm.createContext({
+      sandbox,
+      console: {
+        log: (...args) => {
+          events.push({ event: 'log', value: args.join(' ') });
+        },
+      },
+      __trace: (line) => {
+        events.push({ event: 'step', line, locals: { ...sandbox } });
+      },
+    }),
+    sandbox,
+  };
+}
+
+describe('instrumentJavaScript', () => {
+  test('handles let/const in strings and comments', async () => {
+    const source =
+      `// comment with let and const\n` +
+      `const msg = "let inside string"; // inline const\n` +
+      `let x = 1;\n` +
+      `console.log(msg);`;
+    const instrumented = instrumentJavaScript(source);
+
+    expect(instrumented).toContain('comment with let and const');
+    expect(instrumented).toContain('"let inside string"');
+    expect(instrumented).toMatch(/var msg/);
+    expect(instrumented).toMatch(/var x/);
+
+    const events = [];
+    const { context } = createContext(events);
+    const script = new vm.Script(instrumented);
+    await script.runInContext(context);
+
+    const logEvent = events.find((e) => e.event === 'log');
+    expect(logEvent.value).toBe('let inside string');
+    expect(events.filter((e) => e.event === 'step').length).toBeGreaterThan(0);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -23,7 +23,11 @@
     "mongoose": "^8.0.2",
     "nodemon": "^3.0.2",
     "path": "^0.12.7",
-    "uuid": "^11.1.0"
+    "uuid": "^11.1.0",
+    "@babel/parser": "^7.23.6",
+    "@babel/traverse": "^7.23.7",
+    "@babel/generator": "^7.23.6",
+    "@babel/types": "^7.23.6"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.23.6",


### PR DESCRIPTION
## Summary
- replace regex-based JS instrumentation with Babel AST traversal that injects `__trace` calls and rewrites declarations
- add unit test ensuring strings and comments containing `let`/`const` remain unchanged
- declare Babel parser/generator/traverse/types dependencies

## Testing
- `npm install @babel/parser @babel/traverse @babel/generator @babel/types` *(fails: 403 Forbidden)*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_b_68b83279b5888323a6d9b3f5f39b32a6