### PR TITLE
feat: add code visualizer navigation

### DIFF
--- a/client/src/components/Header.jsx
+++ b/client/src/components/Header.jsx
@@ -39,6 +39,7 @@ function CommandMenu({ isOpen, onClose }) {
   const quickLinks = [
     { label: 'Profile', path: '/dashboard?tab=profile' },
     { label: 'Create a Post', path: '/create-post' },
+    { label: 'Code Visualizer', path: '/visualizer' },
   ];
   const handleSubmit = (e) => {
     e.preventDefault();
@@ -84,6 +85,7 @@ const navLinks = [
   { label: 'Tutorials', path: '/tutorials', id: 'tutorial-link' },
   { label: 'Quizzes', path: '/quizzes', id: 'quiz-link' },
   { label: 'Code Editor', path: '/tryit', id: 'editor-link' },
+  // Direct link to the execution visualizer page
   { label: 'Code Visualizer', path: '/visualizer', id: 'visualizer-link' },
   { label: 'Projects', path: '/projects' },
   { label: 'About', path: '/about' },


### PR DESCRIPTION
## Summary
- expose Code Visualizer via a new quick link in the header command menu
- document the Code Visualizer entry in main navigation

## Testing
- `npm test` *(fails: sh: 1: jest: not found)*
- `npm install` *(fails: npm error code E403; 403 Forbidden for @babel/generator)*

------
https://chatgpt.com/codex/tasks/task_b_68b8383ad7808323afa5bb5985a2ef78