### PR TITLE
fix: ensure babel traverse imported correctly

### DIFF
--- a/api/controllers/execution.controller.js
+++ b/api/controllers/execution.controller.js
@@ -6,9 +6,11 @@ import path from 'path';
 import { v4 as uuidv4 } from 'uuid';
 import { errorHandler } from '../utils/error.js';
 import { parse } from '@babel/parser';
-import traverse from '@babel/traverse';
+import traverseModule from '@babel/traverse';
 import generate from '@babel/generator';
 import * as t from '@babel/types';
+
+const traverse = traverseModule.default ?? traverseModule;
 
 const execFileAsync = promisify(execFile);
 const __dirname = path.resolve();


### PR DESCRIPTION
## Summary
- fix Babel traverse import for JavaScript code instrumentation

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_68b83ac9278c8323835ea67ef3dc6665