### PR TITLE
fix: ensure babel generator default export

### DIFF
--- a/api/controllers/execution.controller.js
+++ b/api/controllers/execution.controller.js
@@ -7,10 +7,11 @@ import { v4 as uuidv4 } from 'uuid';
 import { errorHandler } from '../utils/error.js';
 import { parse } from '@babel/parser';
 import traverseModule from '@babel/traverse';
-import generate from '@babel/generator';
+import generateModule from '@babel/generator';
 import * as t from '@babel/types';
 
 const traverse = traverseModule.default ?? traverseModule;
+const generate = generateModule.default ?? generateModule;
 
 const execFileAsync = promisify(execFile);
 const __dirname = path.resolve();


### PR DESCRIPTION
## Summary
- fix "generate is not a function" in code visualizer by normalizing `@babel/generator` import

## Testing
- `npm test` (fails: jest not found)
- `npm install` (fails: 403 Forbidden fetching @babel/generator)


------
https://chatgpt.com/codex/tasks/task_b_68b83c66e1508323856e1f27d4545763