### PR TITLE
feat: enhance code visualizer

### DIFF
--- a/client/src/components/__tests__/ExecutionVisualizer.test.jsx
+++ b/client/src/components/__tests__/ExecutionVisualizer.test.jsx
@@ -1,0 +1,36 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import ExecutionVisualizer from '../ExecutionVisualizer';
+
+// Mock the Monaco editor to a simple textarea for tests
+jest.mock('@monaco-editor/react', () => ({
+  __esModule: true,
+  default: ({ value, onChange }) => (
+    <textarea data-testid="editor" value={value} onChange={(e) => onChange(e.target.value)} />
+  ),
+}));
+
+// Minimal mock for d3 to avoid DOM manipulation during tests
+jest.mock('d3', () => ({
+  select: () => ({
+    selectAll: () => ({ remove: jest.fn() }),
+  }),
+}));
+
+describe('ExecutionVisualizer', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  test('reset button restores default code snippet', () => {
+    render(<ExecutionVisualizer />);
+
+    const editor = screen.getByTestId('editor');
+    fireEvent.change(editor, { target: { value: 'console.log("test")' } });
+    expect(editor.value).toBe('console.log("test")');
+
+    const resetBtn = screen.getByText('Reset Code');
+    fireEvent.click(resetBtn);
+
+    expect(editor.value).toContain('function greet');
+  });
+});

--- a/client/src/pages/CodeVisualizer.jsx
+++ b/client/src/pages/CodeVisualizer.jsx
@@ -7,7 +7,9 @@ export default function CodeVisualizer() {
             <div className="max-w-4xl mx-auto">
                 <h1 className="text-3xl font-bold mb-2">Code Visualizer</h1>
                 <p className="mb-4 text-gray-600 dark:text-gray-300">
-                    Write code and visualize its execution step by step.
+                    Write code and visualize its execution step by step. Press
+                    <kbd className="px-1">Ctrl</kbd>+<kbd className="px-1">Enter</kbd> to run or use the
+                    reset button to restore the default snippet.
                 </p>
                 <ExecutionVisualizer />
             </div>


### PR DESCRIPTION
## Summary
- persist code per language and add reset capability in ExecutionVisualizer
- support Ctrl+Enter keyboard shortcut for quick execution
- document shortcut and reset in CodeVisualizer page

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@babel%2fgenerator)*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_b_68b85cd082dc83239dd6164001f47caa