### PR TITLE
Fix Python tracer step visualization

### DIFF
--- a/api/utils/pythonTracer.py
+++ b/api/utils/pythonTracer.py
@@ -5,16 +5,19 @@ import runpy
 
 traces = []
 
+
 def tracefunc(frame, event, arg):
-    if event in ('call', 'line', 'return'):
+    if event == 'line':
         traces.append({
-            'event': event,
+            'event': 'step',
             'line': frame.f_lineno,
-            'locals': {k: repr(v) for k, v in frame.f_locals.items()}
+            'locals': {k: repr(v) for k, v in frame.f_locals.items()},
         })
     return tracefunc
 
 def main(script_path):
+    global traces
+    traces = []
     with open(script_path, 'r') as f:
         code = f.read()
     stdout_buffer = io.StringIO()


### PR DESCRIPTION
## Summary
- Normalize Python tracer events to `step` and record only executed lines
- Reset trace list on each run to avoid stale events

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_b_68b8dfbf532c8323a035789ca943a335