### PR TITLE
feat: add python debugger and frontend controls

### DIFF
--- a/api/routes/execute.route.js
+++ b/api/routes/execute.route.js
@@ -1,8 +1,10 @@
 import express from 'express';
-import { executeCode } from '../controllers/execution.controller.js';
+import { executeCode, startDebugSession, debuggerCommand } from '../controllers/execution.controller.js';
 
 const router = express.Router();
 
 router.post('/execute', executeCode);
+router.post('/debug/start', startDebugSession);
+router.post('/debug/command', debuggerCommand);
 
 export default router;


### PR DESCRIPTION
## Summary
- implement bdb-based Python tracer supporting call stack, breakpoints, call/return/exception events
- expose debugging session endpoints with step, next, continue, and breakpoint commands
- add frontend debugging controls with breakpoint persistence and call stack/variable panels

## Testing
- `npm test` *(fails: jest not found)*


------
https://chatgpt.com/codex/tasks/task_b_68b9558631c08323953060ffbce57d81